### PR TITLE
fix(server): harden startup and role handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ mcp-server-error.log
 *_LOG.md
 *_STATUS.md
 test_*.py
+!tests/test_*.py
 ralph-loop.local.md
 AGENTS.md
 *.tgz

--- a/discord_py_self_mcp/main.py
+++ b/discord_py_self_mcp/main.py
@@ -33,8 +33,11 @@ async def call_tool(
 async def run_app():
     token = os.getenv("DISCORD_TOKEN")
     if not token:
-        logger.error("DISCORD_TOKEN environment variable not set")
-        return
+        sys.stderr.write(
+            "Error: DISCORD_TOKEN is not set. Configure it in your MCP client or run "
+            "`discord-py-self-mcp-setup`.\n"
+        )
+        raise SystemExit(1)
 
     logger.info(f"Starting Discord connection...")
     logger.info(

--- a/discord_py_self_mcp/tools/members.py
+++ b/discord_py_self_mcp/tools/members.py
@@ -118,7 +118,13 @@ async def add_role(arguments: dict):
         role_id = int(arguments["role_id"])
         
         guild = client.get_guild(guild_id)
+        if not guild:
+            return [TextContent(type="text", text="Guild not found")]
+
         member = guild.get_member(user_id) or await guild.fetch_member(user_id)
+        if not member:
+            return [TextContent(type="text", text="Member not found")]
+
         role = guild.get_role(role_id)
         
         if not role:
@@ -149,7 +155,13 @@ async def remove_role(arguments: dict):
         role_id = int(arguments["role_id"])
         
         guild = client.get_guild(guild_id)
+        if not guild:
+            return [TextContent(type="text", text="Guild not found")]
+
         member = guild.get_member(user_id) or await guild.fetch_member(user_id)
+        if not member:
+            return [TextContent(type="text", text="Member not found")]
+
         role = guild.get_role(role_id)
         
         if not role:

--- a/discord_py_self_mcp/tools/registry.py
+++ b/discord_py_self_mcp/tools/registry.py
@@ -26,7 +26,10 @@ class ToolRegistry:
     async def call_tool(self, name: str, arguments: dict) -> list[TextContent | ImageContent | EmbeddedResource]:
         handler = self.handlers.get(name)
         if not handler:
-            raise ValueError(f"Tool {name} not found")
+            available_tools = ", ".join(sorted(self.handlers))
+            raise ValueError(
+                f"Unknown tool '{name}'. Available tools: {available_tools}"
+            )
         return await handler(arguments)
 
 registry = ToolRegistry()

--- a/discord_py_self_mcp/tools/relationships.py
+++ b/discord_py_self_mcp/tools/relationships.py
@@ -51,7 +51,7 @@ async def send_friend_request(arguments: dict):
                         break
                 else:
                     # New username system or no discrim provided
-                    if user.discriminator == "0" or not discriminator:
+                    if user.discriminator == "0":
                         target_user = user
                         break
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "mcp",
     "python-dotenv",
     "playwright",
+    "hcaptcha-challenger[playwright]",
+    "loguru",
     "audioop-lts; python_version >= '3.13'",
     "camoufox[geoip]",
     "tls-client",
@@ -27,7 +29,17 @@ dependencies = [
     "requests"
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest>=9.0",
+    "pytest-asyncio>=1.0",
+]
+
 [project.scripts]
 discord-py-self-mcp = "discord_py_self_mcp.main:main"
 discord-py-self-mcp-setup = "discord_py_self_mcp.setup:main"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+asyncio_mode = "auto"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,16 @@
+import pytest
+
+from discord_py_self_mcp import main
+
+
+@pytest.mark.asyncio
+async def test_run_app_exits_with_actionable_error_when_token_missing(
+    monkeypatch, capsys
+):
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        await main.run_app()
+
+    assert exc.value.code == 1
+    assert "DISCORD_TOKEN is not set" in capsys.readouterr().err

--- a/tests/test_members.py
+++ b/tests/test_members.py
@@ -1,0 +1,90 @@
+import pytest
+
+from discord_py_self_mcp.tools import members
+
+
+class FakeClient:
+    def __init__(self, guild):
+        self._guild = guild
+
+    def get_guild(self, guild_id):
+        return self._guild
+
+
+class FakeMember:
+    def __init__(self, name="test-user"):
+        self.name = name
+        self.removed_roles = []
+
+    async def remove_roles(self, role):
+        self.removed_roles.append(role)
+
+
+class FakeRole:
+    def __init__(self, name="mod"):
+        self.name = name
+
+
+class FakeGuild:
+    def __init__(self, member=None, fetched_member=None, role=None):
+        self._member = member
+        self._fetched_member = fetched_member
+        self._role = role
+
+    def get_member(self, user_id):
+        return self._member
+
+    async def fetch_member(self, user_id):
+        return self._fetched_member
+
+    def get_role(self, role_id):
+        return self._role
+
+
+@pytest.mark.asyncio
+async def test_add_role_returns_guild_not_found(monkeypatch):
+    monkeypatch.setattr(members, "client", FakeClient(None))
+
+    result = await members.add_role(
+        {"guild_id": "1", "user_id": "2", "role_id": "3"}
+    )
+
+    assert result[0].text == "Guild not found"
+
+
+@pytest.mark.asyncio
+async def test_add_role_returns_member_not_found(monkeypatch):
+    guild = FakeGuild(member=None, fetched_member=None, role=FakeRole())
+    monkeypatch.setattr(members, "client", FakeClient(guild))
+
+    result = await members.add_role(
+        {"guild_id": "1", "user_id": "2", "role_id": "3"}
+    )
+
+    assert result[0].text == "Member not found"
+
+
+@pytest.mark.asyncio
+async def test_remove_role_returns_guild_not_found(monkeypatch):
+    monkeypatch.setattr(members, "client", FakeClient(None))
+
+    result = await members.remove_role(
+        {"guild_id": "1", "user_id": "2", "role_id": "3"}
+    )
+
+    assert result[0].text == "Guild not found"
+
+
+@pytest.mark.asyncio
+async def test_remove_role_removes_role(monkeypatch):
+    member = FakeMember()
+    role = FakeRole()
+    guild = FakeGuild(member=member, fetched_member=None, role=role)
+    monkeypatch.setattr(members, "client", FakeClient(guild))
+
+    result = await members.remove_role(
+        {"guild_id": "1", "user_id": "2", "role_id": "3"}
+    )
+
+    assert result[0].text == "Removed role mod from test-user"
+    assert member.removed_roles == [role]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,19 @@
+import pytest
+from mcp.types import TextContent
+
+from discord_py_self_mcp.tools.registry import ToolRegistry
+
+
+@pytest.mark.asyncio
+async def test_call_tool_lists_available_tools_for_unknown_name():
+    registry = ToolRegistry()
+
+    async def alpha_handler(arguments):
+        return [TextContent(type="text", text=str(arguments))]
+
+    registry.register("alpha", "Alpha tool", {"type": "object"})(alpha_handler)
+
+    with pytest.raises(ValueError) as exc:
+        await registry.call_tool("missing", {})
+
+    assert str(exc.value) == "Unknown tool 'missing'. Available tools: alpha"


### PR DESCRIPTION
**What changed**
- guard `add_role` and `remove_role` against missing guilds and members
- fail fast with an actionable stderr message when `DISCORD_TOKEN` is missing
- improve unknown-tool errors to list available tool names
- simplify the redundant discriminator branch in `send_friend_request`
- declare the missing Python runtime dependencies in `pyproject.toml`
- add a minimal pytest harness for the fixed paths

**Verification**
- `. .venv/bin/activate && python -m pytest tests -q`
- `. .venv/bin/activate && python -m build --wheel --sdist`
- `. .venv/bin/activate && python - <<'PY' ... importlib.import_module(...) ... PY`