### PR TITLE
[nightshift] dead-code: remove unused imports in captcha/solver.py

### DIFF
--- a/discord_py_self_mcp/captcha/solver.py
+++ b/discord_py_self_mcp/captcha/solver.py
@@ -2,9 +2,7 @@ import os
 import asyncio
 from pathlib import Path
 from typing import Optional, Dict, Any
-import hcaptcha_challenger
 from hcaptcha_challenger.agent.challenger import AgentV
-from hcaptcha_challenger import models
 from loguru import logger
 
 


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** Dead Code Removal
**Category:** pr
**Changes:** Removed 2 unused imports from `discord_py_self_mcp/captcha/solver.py`:
- `import hcaptcha_challenger` — bare module imported but never referenced (only submodule imports are used)
- `from hcaptcha_challenger import models` — imported but never used anywhere in the file

**Analysis Summary:**
The codebase is very clean. Most function definitions that appear "dead" to static analysis are actually registered MCP tool handlers invoked dynamically via `@registry.register()`. No truly dead functions, classes, or files were found.

One borderline case: `RateLimiter.reset()` is defined but never called — however, it serves as public API surface and may be called by consumers, so it was left intact.

Merge if useful, close if not.