### PR TITLE
feat: reliable slash-command resolution + list_dm_channels tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ powered by the robust `discord.py-self` library.
 | **system** | 2 | get_user_info, list_guilds |
 | **messages** | 6 | send_message, read_messages, search_messages, edit_message, delete_message, get_message_attachments |
 | **channels** | 3 | create_channel, delete_channel, list_channels |
+| **dms** | 1 | list_dm_channels |
 | **voice** | 2 | join_voice_channel, leave_voice_channel |
 | **relationships** | 4 | list_friends, send_friend_request, add_friend, remove_friend |
 | **presence** | 2 | set_status, set_activity |
@@ -196,6 +197,34 @@ powered by the robust `discord.py-self` library.
 | **profile** | 1 | edit_profile |
 | **reactions** | 2 | add_reaction, remove_reaction |
 | **discrawl** | 7 | run_discrawl, discrawl_doctor, discrawl_status, discrawl_sync, discrawl_search, discrawl_messages, discrawl_mentions |
+
+### direct messages
+
+`list_dm_channels` enumerates your open 1:1 and group DM channels so you can
+discover a `channel_id` instead of needing to know it in advance. Each row is
+`<channel_id> - [dm|group] <recipient display> (id=<user_id>) [BOT]`. Optional
+args: `include_groups` (default `true`) and `name_contains` (case-insensitive
+filter on recipient name/handle), e.g. find the DM with a person by name and
+feed the id straight into `read_messages` / `send_message`.
+
+### slash commands
+
+`send_slash_command` invokes an application command in a channel or DM. Pass
+`application_id` (the bot's user/application ID) for reliable resolution; in a DM
+with a bot it is inferred automatically. The command and any options are
+resolved from the application's registered command list
+(`GET /applications/{id}/commands`), which works for ordinary guild-installed
+bots whose commands the per-channel `/` search index does not return. Subcommands
+are space-separated in `command_name` (e.g. `"config set"`). Example:
+
+```json
+{
+  "channel_id": "123456789012345678",
+  "command_name": "remind",
+  "application_id": "987654321098765432",
+  "options": { "text": "stand up", "when": "in 10 minutes" }
+}
+```
 
 ### discrawl integration
 
@@ -336,6 +365,7 @@ discord_py_self_mcp/
 │   └── solver.py
 └── tools/
     ├── channels.py
+    ├── dms.py
     ├── discrawl.py
     ├── embed.py
     ├── guilds.py

--- a/discord_py_self_mcp/tools/__init__.py
+++ b/discord_py_self_mcp/tools/__init__.py
@@ -2,6 +2,7 @@ from .registry import registry as registry
 from . import messages as messages
 from . import guilds as guilds
 from . import channels as channels
+from . import dms as dms
 from . import relationships as relationships
 from . import voice as voice
 from . import presence as presence

--- a/discord_py_self_mcp/tools/dms.py
+++ b/discord_py_self_mcp/tools/dms.py
@@ -1,0 +1,101 @@
+import discord
+from mcp.types import TextContent
+
+from ..bot import client
+from ..tool_utils import format_user_display
+from .registry import registry
+
+
+def _is_group(channel) -> bool:
+    return getattr(channel, "type", None) == discord.ChannelType.group
+
+
+def _recipient_label(user) -> str:
+    if user is None:
+        return "unknown"
+    display = format_user_display(user)
+    uid = getattr(user, "id", None)
+    bot_tag = " [BOT]" if getattr(user, "bot", False) else ""
+    return f"{display} (id={uid}){bot_tag}"
+
+
+@registry.register(
+    name="list_dm_channels",
+    description=(
+        "List your open direct-message (DM) and group-DM channels with their "
+        "channel IDs and recipients. Use this to discover the channel_id needed "
+        "by read_messages / send_message instead of having to know it in advance."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "include_groups": {
+                "type": "boolean",
+                "description": "Include group DMs (default true).",
+            },
+            "name_contains": {
+                "type": "string",
+                "description": "Case-insensitive filter: only return DMs whose recipient name/handle contains this.",
+            },
+        },
+    },
+)
+async def list_dm_channels(arguments: dict):
+    try:
+        include_groups = arguments.get("include_groups", True)
+        name_contains = (arguments.get("name_contains") or "").strip().lower()
+
+        private_channels = list(getattr(client, "private_channels", []) or [])
+        if not private_channels:
+            return [
+                TextContent(
+                    type="text",
+                    text="No open DM channels are cached. Open a DM in Discord, then try again.",
+                )
+            ]
+
+        lines = []
+        for channel in private_channels:
+            is_group = _is_group(channel)
+            if is_group and not include_groups:
+                continue
+
+            if is_group:
+                recipients = list(getattr(channel, "recipients", []) or [])
+                name = getattr(channel, "name", None)
+                who = "; ".join(_recipient_label(u) for u in recipients) or "(empty group)"
+                searchable = " ".join(
+                    f"{getattr(u, 'global_name', '') or ''} {getattr(u, 'name', '') or ''}"
+                    for u in recipients
+                ).lower()
+                if name:
+                    searchable += " " + name.lower()
+                label = f"[group{' ' + repr(name) if name else ''}] {who}"
+            else:
+                recipient = getattr(channel, "recipient", None)
+                who = _recipient_label(recipient)
+                searchable = (
+                    f"{getattr(recipient, 'global_name', '') or ''} "
+                    f"{getattr(recipient, 'name', '') or ''}"
+                ).lower()
+                label = f"[dm] {who}"
+
+            if name_contains and name_contains not in searchable:
+                continue
+
+            lines.append(f"{channel.id} - {label}")
+
+        if not lines:
+            scope = "DM channels" if include_groups else "1:1 DM channels"
+            extra = f" matching '{name_contains}'" if name_contains else ""
+            return [TextContent(type="text", text=f"No {scope}{extra}.")]
+
+        header = f"{len(lines)} DM channel(s):"
+        return [TextContent(type="text", text=header + "\n" + "\n".join(lines))]
+    except Exception as e:
+        return [
+            TextContent(
+                type="text",
+                text=f"Error listing DM channels: {type(e).__name__}: {str(e)}",
+            )
+        ]

--- a/discord_py_self_mcp/tools/interactions.py
+++ b/discord_py_self_mcp/tools/interactions.py
@@ -6,18 +6,95 @@ from ..bot import client
 from ..tool_utils import NON_MESSAGEABLE_TEXT, apply_rate_limit
 
 
+async def _collect_commands(result):
+    if inspect.isawaitable(result):
+        result = await result
+    if result is None:
+        return []
+    if hasattr(result, "__aiter__"):
+        return [cmd async for cmd in result]
+    return list(result)
+
+
+def _infer_application_id(channel, application_id):
+    """Resolve the application id to use for command lookup.
+
+    Explicit values win. Otherwise, in a DM with a bot we can safely default to
+    the recipient's id - that is the application whose commands are usable there.
+    """
+    if application_id:
+        return str(application_id)
+    recipient = getattr(channel, "recipient", None)
+    if recipient is not None and getattr(recipient, "bot", False):
+        return str(recipient.id)
+    return None
+
+
+async def _resolve_via_application(channel, application_id, root_name):
+    """Resolve a root SlashCommand by listing the application's registered
+    commands (GET /applications/{id}/commands).
+
+    This is the reliable path for guild-installed bots: the per-channel "/"
+    command search index (application-commands/search) returns nothing for many
+    of them, even though their commands work in the Discord client and are
+    fully invokable. Returns (command_or_None, available_command_names).
+    """
+    raw = await client.http.get_application_commands(int(application_id))
+    if not isinstance(raw, list):
+        return None, []
+    # type 1 == CHAT_INPUT (slash). 2/3 are user/message context-menu commands.
+    chat_input = [c for c in raw if c.get("type", 1) == 1]
+    names = [c.get("name") for c in chat_input if c.get("name")]
+    match = next((c for c in chat_input if c.get("name") == root_name), None)
+    if not match:
+        return None, names
+    state = getattr(client, "_connection", None)
+    command = discord.SlashCommand(state=state, data=match, channel=channel)
+    return command, names
+
+
+async def _resolve_via_search(channel, application_id, root_name):
+    """Fallback: resolve via the channel "/" command search index.
+
+    Works when the app id is unknown and the bot is indexed for the channel.
+    Returns the list of matching root SlashCommands (so the caller can detect
+    ambiguity across applications).
+    """
+    commands = []
+    slash_commands = getattr(channel, "slash_commands", None)
+    if callable(slash_commands):
+        commands = await _collect_commands(slash_commands(query=root_name))
+    commands = [c for c in commands if isinstance(c, discord.SlashCommand)]
+    matching = [c for c in commands if getattr(c, "name", None) == root_name]
+    if application_id:
+        matching = [
+            c
+            for c in matching
+            if str(getattr(c, "application_id", "")) == str(application_id)
+        ]
+    return matching
+
+
 @registry.register(
     name="send_slash_command",
-    description="Send a slash command",
+    description=(
+        "Invoke (send) an application slash command in a channel or DM. For a "
+        "bot's commands, pass application_id (the bot's user/application ID); in "
+        "a DM with a bot it is inferred automatically. Subcommands are given "
+        "space-separated in command_name (e.g. 'group sub')."
+    ),
     input_schema={
         "type": "object",
         "properties": {
             "channel_id": {"type": "string"},
-            "command_name": {"type": "string"},
-            "options": {"type": "object", "description": "Command options/arguments"},
+            "command_name": {
+                "type": "string",
+                "description": "Command name, optionally with subcommands, e.g. 'remind' or 'config set'",
+            },
+            "options": {"type": "object", "description": "Command options/arguments by name"},
             "application_id": {
                 "type": "string",
-                "description": "Bot/Application ID (optional if can be inferred, but recommended)",
+                "description": "Bot/Application ID. Strongly recommended; auto-inferred only in a DM with a bot.",
             },
         },
         "required": ["channel_id", "command_name"],
@@ -33,6 +110,9 @@ async def send_slash_command(arguments: dict):
         if command_name.startswith("/"):
             command_name = command_name[1:]
 
+        if not isinstance(options, dict):
+            return [TextContent(type="text", text="options must be an object")]
+
         channel = client.get_channel(channel_id)
         if not channel:
             try:
@@ -45,73 +125,80 @@ async def send_slash_command(arguments: dict):
         if not isinstance(channel, discord.abc.Messageable):
             return [TextContent(type="text", text=NON_MESSAGEABLE_TEXT)]
 
-        if not isinstance(options, dict):
-            return [TextContent(type="text", text="options must be an object")]
-
         parts = [p for p in command_name.split(" ") if p]
         if not parts:
             return [TextContent(type="text", text="Command name is empty")]
         root_name = parts[0]
         subcommand_parts = parts[1:]
 
-        async def _collect_commands(result):
-            if inspect.isawaitable(result):
-                result = await result
-            if result is None:
-                return []
-            if hasattr(result, "__aiter__"):
-                return [cmd async for cmd in result]
-            return list(result)
+        # Resolve the root command. Prefer the application command listing when an
+        # application id is known (explicit or inferred from a bot DM); fall back
+        # to the channel "/" search index only when there is no app id or the
+        # listing failed.
+        resolved_app_id = _infer_application_id(channel, application_id)
+        target_command = None
+        available_names = []
+        app_error = None
+        app_listed = False
 
-        commands = []
-        slash_commands = getattr(channel, "slash_commands", None)
-        if callable(slash_commands):
+        if resolved_app_id:
             try:
-                commands = await _collect_commands(slash_commands(query=root_name))
-            except Exception:
-                commands = []
+                target_command, available_names = await _resolve_via_application(
+                    channel, resolved_app_id, root_name
+                )
+                app_listed = True
+            except Exception as e:
+                app_error = f"{type(e).__name__}: {e}"
 
-        application_commands = getattr(channel, "application_commands", None)
-        if not commands and callable(application_commands):
+        if target_command is None and not app_listed:
             try:
-                commands = await _collect_commands(application_commands())
-            except Exception:
-                commands = []
+                matching = await _resolve_via_search(channel, application_id, root_name)
+            except Exception as e:
+                detail = app_error or f"{type(e).__name__}: {e}"
+                return [
+                    TextContent(
+                        type="text",
+                        text=f"Could not fetch commands for '/{root_name}': {detail}",
+                    )
+                ]
+            if len(matching) > 1 and not application_id:
+                choices = ", ".join(
+                    f"{c.name} (app_id={getattr(c, 'application_id', 'unknown')})"
+                    for c in matching
+                )
+                return [
+                    TextContent(
+                        type="text",
+                        text=(
+                            f"Multiple commands named '{root_name}' found. Provide "
+                            f"application_id. Options: {choices}"
+                        ),
+                    )
+                ]
+            target_command = matching[0] if matching else None
 
-        if commands:
-            commands = [
-                cmd for cmd in commands if isinstance(cmd, discord.SlashCommand)
-            ]
-
-        matching = [cmd for cmd in commands if getattr(cmd, "name", None) == root_name]
-        if application_id:
-            matching = [
-                cmd
-                for cmd in matching
-                if str(getattr(cmd, "application_id", "")) == str(application_id)
-            ]
-
-        if not matching:
+        if target_command is None:
+            if available_names:
+                hint = (
+                    " Available for this application: "
+                    + ", ".join("/" + n for n in available_names)
+                    + "."
+                )
+            elif not resolved_app_id:
+                hint = (
+                    " Tip: pass application_id (the bot's ID) - the channel '/' "
+                    "search index returns nothing for many guild-installed bots."
+                )
+            else:
+                hint = ""
+            suffix = f" ({app_error})" if app_error else ""
             return [
                 TextContent(
-                    type="text", text=f"Command '{root_name}' not found in channel"
+                    type="text", text=f"Command '/{root_name}' not found.{hint}{suffix}"
                 )
             ]
 
-        if len(matching) > 1 and not application_id:
-            choices = ", ".join(
-                f"{cmd.name} (app_id={getattr(cmd, 'application_id', 'unknown')})"
-                for cmd in matching
-            )
-            return [
-                TextContent(
-                    type="text",
-                    text=f"Multiple commands named '{root_name}' found. Provide application_id. Options: {choices}",
-                )
-            ]
-
-        target_command = matching[0]
-
+        # Navigate subcommands / groups.
         if subcommand_parts:
             current = target_command
             for part in subcommand_parts:
@@ -146,16 +233,40 @@ async def send_slash_command(arguments: dict):
                     )
                 ]
             target_command = current
+        elif getattr(target_command, "is_group", None) and target_command.is_group():
+            children = getattr(target_command, "children", []) or []
+            available = (
+                ", ".join(child.name for child in children) if children else "none"
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"'/{root_name}' is a command group; specify a subcommand. Available: {available}",
+                )
+            ]
+
+        # Surface (rather than silently drop) options the command does not define.
+        known_opts = {o.name for o in getattr(target_command, "options", []) or []}
+        unknown = [k for k in options if k not in known_opts]
 
         await apply_rate_limit("action")
-        await target_command(channel, **options)
-        return [
-            TextContent(type="text", text=f"Executed slash command: /{' '.join(parts)}")
-        ]
+        interaction = await target_command(channel, **options)
+
+        msg = f"Executed slash command: /{' '.join(parts)}"
+        interaction_id = getattr(interaction, "id", None)
+        if interaction_id:
+            msg += f" (interaction {interaction_id})"
+        if unknown:
+            valid = ", ".join(sorted(known_opts)) or "none"
+            msg += f". Ignored unknown option(s) {unknown}; valid options: {valid}"
+        return [TextContent(type="text", text=msg)]
 
     except Exception as e:
         return [
-            TextContent(type="text", text=f"Error executing slash command: {str(e)}")
+            TextContent(
+                type="text",
+                text=f"Error executing slash command: {type(e).__name__}: {str(e)}",
+            )
         ]
 
 

--- a/tests/test_dms.py
+++ b/tests/test_dms.py
@@ -1,0 +1,112 @@
+import discord
+import pytest
+
+from discord_py_self_mcp.tools import dms
+
+
+class FakeUser:
+    def __init__(self, uid, name, global_name=None, discriminator="0", bot=False):
+        self.id = uid
+        self.name = name
+        self.global_name = global_name
+        self.discriminator = discriminator
+        self.bot = bot
+
+
+class FakeDM:
+    type = discord.ChannelType.private
+
+    def __init__(self, channel_id, recipient):
+        self.id = channel_id
+        self.recipient = recipient
+
+
+class FakeGroup:
+    type = discord.ChannelType.group
+
+    def __init__(self, channel_id, recipients, name=None):
+        self.id = channel_id
+        self.recipients = recipients
+        self.name = name
+
+
+class FakeClient:
+    def __init__(self, private_channels):
+        self.private_channels = private_channels
+
+
+@pytest.mark.asyncio
+async def test_empty(monkeypatch):
+    monkeypatch.setattr(dms, "client", FakeClient([]))
+    result = await dms.list_dm_channels({})
+    assert "No open DM channels are cached" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_lists_dm_and_group(monkeypatch):
+    carol = FakeUser(1001, "carol")
+    alice = FakeUser(2001, "alice")
+    bob = FakeUser(2002, "bob")
+    channels = [
+        FakeDM(500, carol),
+        FakeGroup(600, [alice, bob], name="planning"),
+    ]
+    monkeypatch.setattr(dms, "client", FakeClient(channels))
+
+    result = await dms.list_dm_channels({})
+    text = result[0].text
+    assert "2 DM channel(s):" in text
+    assert "500 - [dm] carol (id=1001)" in text
+    assert "600 - [group 'planning']" in text
+    assert "alice (id=2001)" in text and "bob (id=2002)" in text
+
+
+@pytest.mark.asyncio
+async def test_exclude_groups(monkeypatch):
+    carol = FakeUser(1001, "carol")
+    alice = FakeUser(2001, "alice")
+    channels = [FakeDM(500, carol), FakeGroup(600, [alice])]
+    monkeypatch.setattr(dms, "client", FakeClient(channels))
+
+    result = await dms.list_dm_channels({"include_groups": False})
+    text = result[0].text
+    assert "1 DM channel(s):" in text
+    assert "500 - [dm]" in text
+    assert "600" not in text
+
+
+@pytest.mark.asyncio
+async def test_name_filter(monkeypatch):
+    carol = FakeUser(1001, "carol")
+    dave = FakeUser(1002, "dave")
+    channels = [FakeDM(500, carol), FakeDM(501, dave)]
+    monkeypatch.setattr(dms, "client", FakeClient(channels))
+
+    result = await dms.list_dm_channels({"name_contains": "carol"})
+    text = result[0].text
+    assert "1 DM channel(s):" in text
+    assert "500 - [dm] carol" in text
+    assert "501" not in text
+
+
+@pytest.mark.asyncio
+async def test_bot_tag(monkeypatch):
+    helper = FakeUser(555000111222333444, "helperbot", bot=True)
+    channels = [FakeDM(700, helper)]
+    monkeypatch.setattr(dms, "client", FakeClient(channels))
+
+    result = await dms.list_dm_channels({})
+    text = result[0].text
+    assert "[BOT]" in text
+    assert "helperbot" in text
+
+
+@pytest.mark.asyncio
+async def test_global_name_display(monkeypatch):
+    user = FakeUser(1003, "nightowl", global_name="Owl")
+    channels = [FakeDM(800, user)]
+    monkeypatch.setattr(dms, "client", FakeClient(channels))
+
+    result = await dms.list_dm_channels({})
+    # format_user_display -> "Owl (@nightowl)"
+    assert "Owl (@nightowl)" in result[0].text

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,0 +1,266 @@
+import discord
+import pytest
+
+from discord_py_self_mcp.tools import interactions
+
+
+# --- Fakes -------------------------------------------------------------------
+
+
+class FakeUser:
+    def __init__(self, uid, name="bot", bot=True):
+        self.id = uid
+        self.name = name
+        self.bot = bot
+
+
+class FakeOption:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeSlashCommand:
+    """Stand-in for discord.SlashCommand. Constructable from (state, data,
+    channel) like the real class, callable like a command."""
+
+    def __init__(self, *, state=None, data=None, channel=None):
+        data = data or {}
+        self.name = data.get("name")
+        self.options = [FakeOption(o["name"]) for o in data.get("options", [])]
+        self.children = [
+            FakeSubCommand(c["name"]) for c in data.get("children", [])
+        ]
+        self.application_id = data.get("application_id")
+        self.channel = channel
+        self.called_with = None
+
+    def is_group(self):
+        return bool(self.children)
+
+    async def __call__(self, channel, **opts):
+        self.called_with = (channel, opts)
+        return type("Interaction", (), {"id": 12345})()
+
+
+class FakeSubCommand:
+    def __init__(self, name, children=None, options=None):
+        self.name = name
+        self.children = children or []
+        self.options = options or []
+        self.called_with = None
+
+    def is_group(self):
+        return bool(self.children)
+
+    async def __call__(self, channel, **opts):
+        self.called_with = (channel, opts)
+        return type("Interaction", (), {"id": 67890})()
+
+
+class FakeChannel(discord.abc.Messageable):
+    def __init__(self, channel_id=1, recipient=None, search=None):
+        self.id = channel_id
+        self.recipient = recipient
+        self._search = search or []
+
+    async def _get_channel(self):
+        return self
+
+    def slash_commands(self, query=None, **kw):
+        results = self._search
+
+        async def gen():
+            for c in results:
+                yield c
+
+        return gen()
+
+
+class FakeHTTP:
+    def __init__(self, commands=None, error=None):
+        self._commands = commands if commands is not None else []
+        self._error = error
+
+    async def get_application_commands(self, app_id):
+        if self._error:
+            raise self._error
+        return self._commands
+
+
+class FakeClient:
+    def __init__(self, channel=None, commands=None, http_error=None, no_channel=False):
+        self._channel = channel
+        self.http = FakeHTTP(commands=commands, error=http_error)
+        self._connection = object()
+        self._no_channel = no_channel
+
+    def get_channel(self, channel_id):
+        return None if self._no_channel else self._channel
+
+    async def fetch_channel(self, channel_id):
+        if self._no_channel:
+            raise discord.NotFound  # type: ignore[call-arg]
+        return self._channel
+
+
+# --- _infer_application_id ----------------------------------------------------
+
+
+def test_infer_application_id_explicit_wins():
+    ch = FakeChannel(recipient=FakeUser(99, bot=True))
+    assert interactions._infer_application_id(ch, "555") == "555"
+
+
+def test_infer_application_id_bot_dm():
+    ch = FakeChannel(recipient=FakeUser(777, bot=True))
+    assert interactions._infer_application_id(ch, None) == "777"
+
+
+def test_infer_application_id_non_bot_dm_is_none():
+    ch = FakeChannel(recipient=FakeUser(777, bot=False))
+    assert interactions._infer_application_id(ch, None) is None
+
+
+def test_infer_application_id_no_recipient_is_none():
+    ch = FakeChannel(recipient=None)
+    assert interactions._infer_application_id(ch, None) is None
+
+
+# --- send_slash_command -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_options_must_be_object(monkeypatch):
+    monkeypatch.setattr(interactions, "client", FakeClient())
+    result = await interactions.send_slash_command(
+        {"channel_id": "1", "command_name": "x", "options": "not-a-dict"}
+    )
+    assert result[0].text == "options must be an object"
+
+
+@pytest.mark.asyncio
+async def test_channel_not_found(monkeypatch):
+    monkeypatch.setattr(interactions, "client", FakeClient(no_channel=True))
+    result = await interactions.send_slash_command(
+        {"channel_id": "1", "command_name": "x"}
+    )
+    assert result[0].text == "Channel not found"
+
+
+@pytest.mark.asyncio
+async def test_executes_via_application_listing(monkeypatch):
+    channel = FakeChannel(channel_id=10)
+    commands = [
+        {"name": "help", "id": "1", "version": "2", "type": 1, "application_id": "123", "options": []}
+    ]
+    monkeypatch.setattr(interactions, "client", FakeClient(channel=channel, commands=commands))
+    monkeypatch.setattr(discord, "SlashCommand", FakeSlashCommand)
+
+    result = await interactions.send_slash_command(
+        {"channel_id": "10", "command_name": "help", "application_id": "123"}
+    )
+    assert result[0].text.startswith("Executed slash command: /help")
+    assert "interaction 12345" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_infers_app_id_in_bot_dm(monkeypatch):
+    channel = FakeChannel(channel_id=20, recipient=FakeUser(123, bot=True))
+    commands = [
+        {"name": "stats", "id": "1", "version": "2", "type": 1, "application_id": "123", "options": []}
+    ]
+    monkeypatch.setattr(interactions, "client", FakeClient(channel=channel, commands=commands))
+    monkeypatch.setattr(discord, "SlashCommand", FakeSlashCommand)
+
+    result = await interactions.send_slash_command(
+        {"channel_id": "20", "command_name": "stats"}
+    )
+    assert result[0].text.startswith("Executed slash command: /stats")
+
+
+@pytest.mark.asyncio
+async def test_not_found_lists_available_commands(monkeypatch):
+    channel = FakeChannel(channel_id=10)
+    commands = [
+        {"name": "help", "id": "1", "version": "2", "type": 1, "application_id": "123", "options": []},
+        {"name": "stats", "id": "2", "version": "2", "type": 1, "application_id": "123", "options": []},
+    ]
+    monkeypatch.setattr(interactions, "client", FakeClient(channel=channel, commands=commands))
+    monkeypatch.setattr(discord, "SlashCommand", FakeSlashCommand)
+
+    result = await interactions.send_slash_command(
+        {"channel_id": "10", "command_name": "nope", "application_id": "123"}
+    )
+    text = result[0].text
+    assert "not found" in text
+    assert "/help" in text and "/stats" in text
+
+
+@pytest.mark.asyncio
+async def test_unknown_option_is_reported(monkeypatch):
+    channel = FakeChannel(channel_id=10)
+    commands = [
+        {"name": "greet", "id": "1", "version": "2", "type": 1, "application_id": "123",
+         "options": [{"name": "text", "type": 3}]}
+    ]
+    monkeypatch.setattr(interactions, "client", FakeClient(channel=channel, commands=commands))
+    monkeypatch.setattr(discord, "SlashCommand", FakeSlashCommand)
+
+    result = await interactions.send_slash_command(
+        {"channel_id": "10", "command_name": "greet", "application_id": "123",
+         "options": {"bogus": "x"}}
+    )
+    text = result[0].text
+    assert text.startswith("Executed slash command: /greet")
+    assert "Ignored unknown option(s)" in text and "bogus" in text
+
+
+@pytest.mark.asyncio
+async def test_group_without_subcommand_is_rejected(monkeypatch):
+    channel = FakeChannel(channel_id=10)
+    commands = [
+        {"name": "config", "id": "1", "version": "2", "type": 1, "application_id": "123",
+         "children": [{"name": "set"}, {"name": "get"}]}
+    ]
+    monkeypatch.setattr(interactions, "client", FakeClient(channel=channel, commands=commands))
+    monkeypatch.setattr(discord, "SlashCommand", FakeSlashCommand)
+
+    result = await interactions.send_slash_command(
+        {"channel_id": "10", "command_name": "config", "application_id": "123"}
+    )
+    text = result[0].text
+    assert "command group" in text
+    assert "set" in text and "get" in text
+
+
+@pytest.mark.asyncio
+async def test_http_error_is_surfaced_not_masked(monkeypatch):
+    channel = FakeChannel(channel_id=10)
+    monkeypatch.setattr(
+        interactions,
+        "client",
+        FakeClient(channel=channel, http_error=RuntimeError("boom")),
+    )
+    # No fallback possible: app id is explicit, listing failed, search has nothing.
+    result = await interactions.send_slash_command(
+        {"channel_id": "10", "command_name": "x", "application_id": "123"}
+    )
+    text = result[0].text
+    # app listing failed -> search fallback runs -> nothing found -> not found,
+    # and the original RuntimeError is appended so it is not silently masked.
+    assert "not found" in text
+    assert "boom" in text
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_search_without_app_id(monkeypatch):
+    fake_cmd = FakeSlashCommand(data={"name": "foo", "options": []})
+    channel = FakeChannel(channel_id=30, recipient=None, search=[fake_cmd])
+    monkeypatch.setattr(interactions, "client", FakeClient(channel=channel))
+    monkeypatch.setattr(discord, "SlashCommand", FakeSlashCommand)
+
+    result = await interactions.send_slash_command(
+        {"channel_id": "30", "command_name": "foo"}
+    )
+    assert result[0].text.startswith("Executed slash command: /foo")
+    assert fake_cmd.called_with is not None


### PR DESCRIPTION
# Fix slash-command resolution + add `list_dm_channels` tool

Two implementation gaps (neither is a Discord API limit):

1. **`send_slash_command` couldn't find most bots' commands.** It resolved only through the per-channel `/` search index, which returns nothing for ordinary guild-installed bots - so it always said "not found." Now it resolves via `GET /applications/{app_id}/commands` (auto-inferring `application_id` in a bot DM), keeps search as a fallback, surfaces real errors, and on a miss lists the app's available commands.

2. **No way to list open DMs.** Added `list_dm_channels` (reads `client.private_channels`) so callers can discover a DM `channel_id` instead of hardcoding it. Filters: `include_groups`, `name_contains`.

## Tests
`pytest` green (existing 25 + 19 new). Also verified live against a real guild-installed bot: command resolved/invoked with inferred app id, and DM listing returned ids + recipients with filters working.

No new deps; no changes to existing tool signatures.