### PR TITLE
feat: reply_to_message_id on send_message + reply id in read_messages

### DIFF
--- a/discord_py_self_mcp/tool_utils.py
+++ b/discord_py_self_mcp/tool_utils.py
@@ -36,6 +36,23 @@ def validate_message_content(content: str) -> str | None:
     return None
 
 
+def build_reply_kwargs(reply_to_message_id: object, channel_id: object) -> dict:
+    """Build channel.send() kwargs for an optional reply reference.
+
+    Returns an empty dict when no reply target is given (None or empty
+    string), so the message is sent normally. Otherwise returns a
+    ``reference`` pointing at the target message in the given channel.
+    """
+    if not reply_to_message_id:
+        return {}
+    return {
+        "reference": discord.MessageReference(
+            message_id=int(reply_to_message_id),
+            channel_id=int(channel_id),
+        )
+    }
+
+
 def normalize_history_limit(limit: object, *, default: int = DEFAULT_HISTORY_LIMIT) -> int:
     try:
         normalized = int(limit)

--- a/discord_py_self_mcp/tools/embed.py
+++ b/discord_py_self_mcp/tools/embed.py
@@ -77,11 +77,19 @@ def format_message_body(message: discord.Message) -> list[str]:
     return parts
 
 
+def get_reply_to_message_id(message: discord.Message):
+    """Return the id of the message this one replies to, or None."""
+    reference = getattr(message, "reference", None)
+    return getattr(reference, "message_id", None) if reference else None
+
+
 def format_message_line(message: discord.Message) -> str:
     author_name = message.author.name if message.author else "Unknown"
-    return f"{author_name} (message_id={message.id}): " + " ".join(
-        format_message_body(message)
-    )
+    header = f"message_id={message.id}"
+    reply_to_id = get_reply_to_message_id(message)
+    if reply_to_id is not None:
+        header += f", reply_to={reply_to_id}"
+    return f"{author_name} ({header}): " + " ".join(format_message_body(message))
 
 
 def build_search_text(message: discord.Message) -> str:
@@ -122,6 +130,7 @@ def serialize_message(message: discord.Message) -> dict:
         "author": message.author.name if message.author else "Unknown",
         "content": get_message_text(message),
         "created_at": message.created_at.isoformat(),
+        "reply_to": get_reply_to_message_id(message),
         "attachments": [
             serialize_attachment(attachment) for attachment in message.attachments
         ],

--- a/discord_py_self_mcp/tools/messages.py
+++ b/discord_py_self_mcp/tools/messages.py
@@ -9,6 +9,7 @@ from .embed import build_search_text, format_attachment, format_message_line
 from ..tool_utils import (
     NON_MESSAGEABLE_TEXT,
     apply_rate_limit,
+    build_reply_kwargs,
     normalize_history_limit,
     validate_message_content,
 )
@@ -54,12 +55,7 @@ async def send_message(arguments: dict):
         if not isinstance(channel, discord.abc.Messageable):
             return [TextContent(type="text", text=NON_MESSAGEABLE_TEXT)]
 
-        send_kwargs = {}
-        if reply_to_message_id is not None:
-            send_kwargs["reference"] = discord.MessageReference(
-                message_id=int(reply_to_message_id),
-                channel_id=channel_id,
-            )
+        send_kwargs = build_reply_kwargs(reply_to_message_id, channel_id)
 
         await apply_rate_limit("message")
         message = await channel.send(content, **send_kwargs)

--- a/discord_py_self_mcp/tools/messages.py
+++ b/discord_py_self_mcp/tools/messages.py
@@ -24,6 +24,10 @@ MAX_ATTACHMENT_BYTES_DEFAULT = 10 * 1024 * 1024
         "properties": {
             "channel_id": {"type": "string"},
             "content": {"type": "string"},
+            "reply_to_message_id": {
+                "type": "string",
+                "description": "Optional message ID to reply to in this channel",
+            },
         },
         "required": ["channel_id", "content"],
     },
@@ -32,6 +36,7 @@ async def send_message(arguments: dict):
     try:
         channel_id = int(arguments["channel_id"])
         content = arguments["content"]
+        reply_to_message_id = arguments.get("reply_to_message_id")
         content_error = validate_message_content(content)
         if content_error:
             return [TextContent(type="text", text=content_error)]
@@ -49,8 +54,15 @@ async def send_message(arguments: dict):
         if not isinstance(channel, discord.abc.Messageable):
             return [TextContent(type="text", text=NON_MESSAGEABLE_TEXT)]
 
+        send_kwargs = {}
+        if reply_to_message_id is not None:
+            send_kwargs["reference"] = discord.MessageReference(
+                message_id=int(reply_to_message_id),
+                channel_id=channel_id,
+            )
+
         await apply_rate_limit("message")
-        message = await channel.send(content)
+        message = await channel.send(content, **send_kwargs)
         return [
             TextContent(
                 type="text",

--- a/scripts/daemon.py
+++ b/scripts/daemon.py
@@ -46,7 +46,11 @@ from discord_py_self_mcp.cli_runtime import (
     ensure_runtime_dir,
 )
 from discord_py_self_mcp.logging_utils import log_to_stderr
-from discord_py_self_mcp.tool_utils import NON_MESSAGEABLE_TEXT, validate_message_content
+from discord_py_self_mcp.tool_utils import (
+    NON_MESSAGEABLE_TEXT,
+    build_reply_kwargs,
+    validate_message_content,
+)
 from discord_py_self_mcp.tools.embed import serialize_attachment, serialize_message
 
 DAEMON_SCRIPT = SCRIPT_DIR / "daemon.py"
@@ -328,13 +332,7 @@ class DiscordDaemon:
         if not isinstance(channel, discord.abc.Messageable):
             return {"error": NON_MESSAGEABLE_TEXT}
 
-        send_kwargs = {}
-        if reply_to_message_id is not None:
-            send_kwargs["reference"] = discord.MessageReference(
-                message_id=int(reply_to_message_id),
-                channel_id=int(channel_id),
-            )
-
+        send_kwargs = build_reply_kwargs(reply_to_message_id, channel_id)
         message = await channel.send(content, **send_kwargs)
         return {"message_id": message.id, "success": True}
 

--- a/scripts/daemon.py
+++ b/scripts/daemon.py
@@ -203,7 +203,9 @@ class DiscordDaemon:
                 )
             if cmd == "send_message":
                 return await self._send_message(
-                    args.get("channel_id"), args.get("content")
+                    args.get("channel_id"),
+                    args.get("content"),
+                    args.get("reply_to_message_id"),
                 )
             if cmd == "get_message_attachments":
                 return await self._get_message_attachments(
@@ -313,7 +315,7 @@ class DiscordDaemon:
         messages.reverse()
         return {"messages": messages}
 
-    async def _send_message(self, channel_id, content):
+    async def _send_message(self, channel_id, content, reply_to_message_id=None):
         content_error = validate_message_content(content or "")
         if content_error:
             return {"error": content_error}
@@ -326,7 +328,14 @@ class DiscordDaemon:
         if not isinstance(channel, discord.abc.Messageable):
             return {"error": NON_MESSAGEABLE_TEXT}
 
-        message = await channel.send(content)
+        send_kwargs = {}
+        if reply_to_message_id is not None:
+            send_kwargs["reference"] = discord.MessageReference(
+                message_id=int(reply_to_message_id),
+                channel_id=int(channel_id),
+            )
+
+        message = await channel.send(content, **send_kwargs)
         return {"message_id": message.id, "success": True}
 
     async def _get_message_attachments(

--- a/scripts/dcli.py
+++ b/scripts/dcli.py
@@ -4,7 +4,7 @@ Usage: python3 dcli.py <command> [args]
 
 Commands:
   daemon <start|stop|restart|status>  - Manage daemon process
-  send-message --channel ID --content "msg"
+  send-message --channel ID --content "msg" [--reply-to MESSAGE_ID]
   read-messages --channel ID [--limit N] [--after TIME]
   get-message-attachments --channel ID --message ID [--attachment-index N] [--download --output-dir DIR]
   list-guilds
@@ -244,11 +244,14 @@ def cmd_get_message_attachments(
         print(f"  {destination}")
 
 
-def cmd_send_message(channel_id, content):
+def cmd_send_message(channel_id, content, reply_to_message_id=None):
+    args = {"channel_id": channel_id, "content": content}
+    if reply_to_message_id is not None:
+        args["reply_to_message_id"] = reply_to_message_id
     result = send_request(
         {
             "command": "send_message",
-            "args": {"channel_id": channel_id, "content": content},
+            "args": args,
         }
     )
     if "error" in result:
@@ -554,6 +557,7 @@ def main():
     send_parser = subparsers.add_parser("send-message", help="Send a message")
     send_parser.add_argument("--channel", "-c", required=True, type=int, help="Channel ID")
     send_parser.add_argument("--content", "-m", required=True, help="Message content")
+    send_parser.add_argument("--reply-to", "-r", type=int, default=None, help="Message ID to reply to")
 
     read_parser = subparsers.add_parser("read-messages", help="Read messages from channel")
     read_parser.add_argument("--channel", "-c", required=True, type=int, help="Channel ID")
@@ -635,7 +639,7 @@ def main():
     if args.command == "daemon":
         cmd_daemon(args.action)
     elif args.command == "send-message":
-        cmd_send_message(args.channel, args.content)
+        cmd_send_message(args.channel, args.content, args.reply_to)
     elif args.command == "read-messages":
         cmd_read_messages(args.channel, args.limit, args.after)
     elif args.command == "get-message-attachments":

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -82,10 +82,13 @@ class FakeMessageable:
 
 
 class FakeChannel(FakeMessageable):
-    def __init__(self, *, messages_list=None, fetched_message=None):
+    def __init__(self, *, messages_list=None, fetched_message=None, sent_message=None):
         self._messages = messages_list or []
         self._fetched_message = fetched_message
+        self._sent_message = sent_message or FakeMessage(message_id=999)
         self.last_history_limit = None
+        self.sent_content = None
+        self.sent_kwargs = None
 
     def history(self, **kwargs):
         limit = kwargs.get("limit", len(self._messages))
@@ -95,6 +98,11 @@ class FakeChannel(FakeMessageable):
     async def fetch_message(self, message_id):
         return self._fetched_message
 
+    async def send(self, content, **kwargs):
+        self.sent_content = content
+        self.sent_kwargs = kwargs
+        return self._sent_message
+
 
 class FakeClient:
     def __init__(self, channel):
@@ -103,6 +111,50 @@ class FakeClient:
 
     def get_channel(self, channel_id):
         return self._channel
+
+
+@pytest.mark.asyncio
+async def test_send_message_without_reply_has_no_reference(monkeypatch):
+    fake_channel = FakeChannel()
+    rate_limit_calls = []
+    monkeypatch.setattr(messages.discord.abc, "Messageable", FakeMessageable)
+    monkeypatch.setattr(messages, "client", FakeClient(fake_channel))
+
+    async def fake_apply_rate_limit(action_type):
+        rate_limit_calls.append(action_type)
+
+    monkeypatch.setattr(messages, "apply_rate_limit", fake_apply_rate_limit)
+
+    result = await messages.send_message({"channel_id": "1", "content": "hi"})
+
+    assert rate_limit_calls == ["message"]
+    assert fake_channel.sent_content == "hi"
+    assert fake_channel.sent_kwargs.get("reference") is None
+    assert "message_id=999" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_send_message_includes_reply_reference(monkeypatch):
+    fake_channel = FakeChannel()
+    rate_limit_calls = []
+    monkeypatch.setattr(messages.discord.abc, "Messageable", FakeMessageable)
+    monkeypatch.setattr(messages, "client", FakeClient(fake_channel))
+
+    async def fake_apply_rate_limit(action_type):
+        rate_limit_calls.append(action_type)
+
+    monkeypatch.setattr(messages, "apply_rate_limit", fake_apply_rate_limit)
+
+    result = await messages.send_message(
+        {"channel_id": "1", "content": "hi", "reply_to_message_id": "456"}
+    )
+
+    assert rate_limit_calls == ["message"]
+    reference = fake_channel.sent_kwargs.get("reference")
+    assert reference is not None
+    assert reference.message_id == 456
+    assert reference.channel_id == 1
+    assert "message_id=999" in result[0].text
 
 
 @pytest.mark.asyncio

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -141,6 +141,27 @@ async def test_send_message_without_reply_has_no_reference(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_message_empty_reply_id_sends_normally(monkeypatch):
+    fake_channel = FakeChannel()
+    monkeypatch.setattr(messages.discord.abc, "Messageable", FakeMessageable)
+    monkeypatch.setattr(messages, "client", FakeClient(fake_channel))
+
+    async def fake_apply_rate_limit(action_type):
+        pass
+
+    monkeypatch.setattr(messages, "apply_rate_limit", fake_apply_rate_limit)
+
+    result = await messages.send_message(
+        {"channel_id": "1", "content": "hi", "reply_to_message_id": ""}
+    )
+
+    assert fake_channel.sent_content == "hi"
+    assert fake_channel.sent_kwargs.get("reference") is None
+    assert "message_id=999" in result[0].text
+    assert "Error" not in result[0].text
+
+
+@pytest.mark.asyncio
 async def test_send_message_includes_reply_reference(monkeypatch):
     fake_channel = FakeChannel()
     rate_limit_calls = []

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -40,6 +40,11 @@ class FakeAttachment:
         return self._payload
 
 
+class FakeReference:
+    def __init__(self, message_id):
+        self.message_id = message_id
+
+
 class FakeMessage:
     def __init__(
         self,
@@ -49,6 +54,7 @@ class FakeMessage:
         content="",
         clean_content="",
         attachments=None,
+        reference=None,
     ):
         self.id = message_id
         self.author = author or FakeAuthor()
@@ -56,6 +62,7 @@ class FakeMessage:
         self.clean_content = clean_content
         self.attachments = attachments or []
         self.embeds = []
+        self.reference = reference
         self.created_at = datetime(2026, 4, 17, 19, 0, tzinfo=timezone.utc)
         self.deleted = False
 
@@ -177,6 +184,37 @@ async def test_read_messages_includes_attachment_metadata(monkeypatch):
     assert "[Attachment 0] photo.png" in result[0].text
     assert "url=https://cdn.discordapp.com/photo.png" in result[0].text
     assert rate_limit_calls == ["action"]
+
+
+@pytest.mark.asyncio
+async def test_read_messages_includes_reply_reference_id(monkeypatch):
+    reply_msg = FakeMessage(
+        message_id=222,
+        content="a reply",
+        clean_content="a reply",
+        reference=FakeReference(message_id=111),
+    )
+    plain_msg = FakeMessage(
+        message_id=333, content="not a reply", clean_content="not a reply"
+    )
+    fake_channel = FakeChannel(messages_list=[reply_msg, plain_msg])
+    monkeypatch.setattr(messages.discord.abc, "Messageable", FakeMessageable)
+    monkeypatch.setattr(messages, "client", FakeClient(fake_channel))
+
+    async def fake_apply_rate_limit(action_type):
+        pass
+
+    monkeypatch.setattr(messages, "apply_rate_limit", fake_apply_rate_limit)
+
+    result = await messages.read_messages({"channel_id": "1", "limit": 5})
+    text = result[0].text
+
+    assert "message_id=222" in text
+    assert "reply_to=111" in text
+    # A non-reply message should not gain a reply_to marker
+    assert "message_id=333" in text
+    plain_line = [line for line in text.splitlines() if "message_id=333" in line][0]
+    assert "reply_to=" not in plain_line
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Adds first-class reply support to `send_message` and surfaces reply context in reads.

- **Send replies**: `send_message` gains an optional `reply_to_message_id`. When set, it builds a `discord.MessageReference(message_id, channel_id)` and sends the message as a reply. Omit or pass empty string for no reply
- **See replies**: `read_messages` / `search_messages` output now includes `reply_to=<id>` in the header when a message is a reply, so you can tell what each message was replying to + matching `reply_to` field in the daemon's `serialize_message`

## Notes
- Uses discord.py-self's default `fail_if_not_exists=True`, so replying to a deleted message surfaces a clean error via the existing handler.
- An empty `reply_to_message_id` is treated as "no reply" (truthy guard), so a client that emits `""` for the optional field still sends a normal message.
- Scope limited to the reply id; `mention_author` is intentionally not exposed.

## Testing
Includes new tests for reply vs no-reply message paths, and reading them