### PR TITLE
fix: accept discrawl.exe on Windows + list_friends Relationship crash

### DIFF
--- a/discord_py_self_mcp/tools/discrawl.py
+++ b/discord_py_self_mcp/tools/discrawl.py
@@ -41,7 +41,8 @@ def _resolve_discrawl_binary(arguments: dict) -> str:
             raise ValueError(
                 "binary must be the literal 'discrawl' or an absolute path to a discrawl executable"
             )
-        if expanded.name != "discrawl":
+        # Accept both POSIX "discrawl" and Windows "discrawl.exe".
+        if expanded.stem != "discrawl":
             raise ValueError("binary path must point to a discrawl executable")
         return str(expanded)
 

--- a/discord_py_self_mcp/tools/relationships.py
+++ b/discord_py_self_mcp/tools/relationships.py
@@ -18,7 +18,14 @@ async def list_friends(arguments: dict):
         if not friends:
              return [TextContent(type="text", text="Your friends list is empty.")]
 
-        friend_list = [f"{format_user_display(f)} ({f.id})" for f in friends]
+        # client.friends returns Relationship objects, not Users. A Relationship
+        # has no .name, so format it via its .user (skipping any relationship
+        # whose user is unavailable).
+        friend_list = [
+            f"{format_user_display(f.user)} ({f.user.id})"
+            for f in friends
+            if f.user is not None
+        ]
         return [TextContent(type="text", text="\n".join(friend_list))]
     except AttributeError:
          return [TextContent(type="text", text="Could not access the friends list. Make sure the Discord account is connected and logged in.")]

--- a/tests/test_discrawl.py
+++ b/tests/test_discrawl.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from discord_py_self_mcp.tools import discrawl
@@ -7,18 +9,37 @@ def test_default_discrawl_candidates_are_fork_only():
     candidates = discrawl._default_discrawl_candidates()
 
     assert len(candidates) == 1
-    assert candidates[0].endswith("discrawl-self/bin/discrawl")
+    assert Path(candidates[0]).parts[-3:] == ("discrawl-self", "bin", "discrawl")
     assert discrawl.DEFAULT_DISCRAWL_BINARY not in candidates
 
 
 def test_default_discrawl_binary_uses_sibling_fork_even_when_missing():
     resolved = discrawl._resolve_discrawl_binary({})
 
-    assert resolved.endswith("discrawl-self/bin/discrawl")
+    assert Path(resolved).parts[-3:] == ("discrawl-self", "bin", "discrawl")
 
 
 def test_explicit_literal_discrawl_is_still_allowed():
     assert discrawl._resolve_discrawl_binary({"binary": "discrawl"}) == "discrawl"
+
+
+def test_explicit_absolute_discrawl_exe_is_accepted(tmp_path):
+    target = tmp_path / "discrawl.exe"
+
+    assert discrawl._resolve_discrawl_binary({"binary": str(target)}) == str(target)
+
+
+def test_explicit_absolute_discrawl_without_extension_is_accepted(tmp_path):
+    target = tmp_path / "discrawl"
+
+    assert discrawl._resolve_discrawl_binary({"binary": str(target)}) == str(target)
+
+
+def test_explicit_absolute_wrong_name_is_rejected(tmp_path):
+    target = tmp_path / "notdiscrawl.exe"
+
+    with pytest.raises(ValueError, match="must point to a discrawl executable"):
+        discrawl._resolve_discrawl_binary({"binary": str(target)})
 
 
 @pytest.mark.asyncio

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,0 +1,63 @@
+import pytest
+
+from discord_py_self_mcp.tools import relationships
+
+
+class FakeUser:
+    def __init__(self, id, name, global_name=None, discriminator="0"):
+        self.id = id
+        self.name = name
+        self.global_name = global_name
+        self.discriminator = discriminator
+
+
+class FakeRelationship:
+    """Mirrors discord.Relationship: exposes .user (and .id) but no .name."""
+
+    def __init__(self, user):
+        self.user = user
+
+    @property
+    def id(self):
+        return self.user.id
+
+
+class FakeClient:
+    def __init__(self, friends):
+        self.friends = friends
+
+
+@pytest.mark.asyncio
+async def test_list_friends_formats_relationship_users(monkeypatch):
+    friends = [
+        FakeRelationship(FakeUser(1, "alice", global_name="Alice")),
+        FakeRelationship(FakeUser(2, "bob")),
+    ]
+    monkeypatch.setattr(relationships, "client", FakeClient(friends))
+
+    result = await relationships.list_friends({})
+
+    # A Relationship has no .name, so it must be formatted via its .user.
+    assert result[0].text == "Alice (@alice) (1)\nbob (2)"
+
+
+@pytest.mark.asyncio
+async def test_list_friends_empty(monkeypatch):
+    monkeypatch.setattr(relationships, "client", FakeClient([]))
+
+    result = await relationships.list_friends({})
+
+    assert result[0].text == "Your friends list is empty."
+
+
+@pytest.mark.asyncio
+async def test_list_friends_skips_relationship_without_user(monkeypatch):
+    friends = [
+        FakeRelationship(FakeUser(1, "alice", global_name="Alice")),
+        FakeRelationship(None),
+    ]
+    monkeypatch.setattr(relationships, "client", FakeClient(friends))
+
+    result = await relationships.list_friends({})
+
+    assert result[0].text == "Alice (@alice) (1)"


### PR DESCRIPTION
Two bugs, both surfaced on Windows; neither is a Discord or discrawl limit:

1. **The documented `DISCRAWL_BIN` override was unusable on Windows.**
   `_resolve_discrawl_binary` validated an explicit binary path with
   `Path.name != "discrawl"`, so pointing `DISCRAWL_BIN` (or the `binary` arg) at the
   real executable `discrawl.exe` raised "binary path must point to a discrawl
   executable." Compare `Path.stem` instead, so both `discrawl` and `discrawl.exe` are
   accepted; other names are still rejected. This leaves the "no silent PATH fallback"
   behavior intact - it only unblocks the documented override on Windows.

2. **`list_friends` always errored.** `client.friends` returns `discord.Relationship`
   objects, not `User`s. A `Relationship` has no `.name`, so `format_user_display(f)`
   fell through to `return user.name` and raised `AttributeError`, reported as the
   misleading "Could not access the friends list. Make sure the Discord account is
   connected and logged in." Format via the relationship's `.user` instead, skipping any
   relationship whose user is unavailable.

## Tests
`pytest` green (58 passing). New: explicit `discrawl.exe` / extensionless-`discrawl`
acceptance + wrong-name rejection, and `list_friends` formatting / empty / user-less
skip. Also made two existing discrawl resolution tests path-separator agnostic so they
pass on Windows. Verified live on Windows: `discrawl status` runs via
`DISCRAWL_BIN=...\discrawl.exe`, and `list_friends` returns the real friend list
(12 entries) instead of the error.

No new deps; no changes to existing tool signatures.