### PR TITLE
fix: pin mcp<2 so the server starts on a fresh install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "discord.py-self[voice]==2.0.1",
-    "mcp",
+    "mcp<2",
     "python-dotenv",
     "playwright",
     "hcaptcha-challenger",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py-self[voice]==2.0.1
-mcp
+mcp<2
 python-dotenv
 playwright
 hcaptcha-challenger


### PR DESCRIPTION
### Problem

`mcp` is unpinned, so a fresh install resolves to **mcp 2.0.0**, which removed the low-level `Server` API that `main.py` uses. The server no longer starts:

```
File "discord_py_self_mcp/main.py", line 14, in <module>
    @app.list_tools()
AttributeError: 'Server' object has no attribute 'list_tools'
```

The test suite shows the same break. With mcp 2.0.0, collection is interrupted before any test runs:

```
ERROR tests/test_main.py - AttributeError: 'Server' object has no attribute 'list_tools'
!!! Interrupted: 1 error during collection !!!
```

Skipping `test_main.py` to see the rest, two more fail on the pydantic model changes that came with 2.0:

```
FAILED tests/test_messages.py::test_get_message_attachments_returns_image_content
FAILED tests/test_profile.py::test_edit_profile_schema_only_exposes_supported_fields
2 failed, 55 passed
```

### Fix

Pin to the 1.x line in both `requirements.txt` and `pyproject.toml`.

### Verification

Same branch, same venv, only the resolved `mcp` version differs:

| mcp | result |
| --- | --- |
| 2.0.0 | collection interrupted; 2 failed, 55 passed when `test_main.py` is skipped |
| 1.29.0 | **58 passed** |

No source changes — this only constrains the dependency. Adapting `main.py` to the 2.x API would be a larger change and is left as a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR constrains MCP to its compatible 1.x release line so fresh installations retain the low-level server API used by the application.
- Adds the same `mcp<2` constraint to both supported dependency manifests.
- Keeps package metadata and requirements-based installations consistent.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and consistently restores installation of an MCP release compatible with the existing server implementation.

Both dependency entry points receive the same narrow upper bound, and no changed-code-triggered blocking or independently actionable non-blocking defect remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Constrains the project dependency to MCP versions below 2, matching the server’s existing API usage. |
| requirements.txt | Applies the same MCP upper bound for requirements-based fresh installations. |

<sub>Reviews (1): Last reviewed commit: ["fix: pin mcp&lt;2 so the server starts on a..."](https://github.com/microck/discord.py-self-mcp/commit/31a5566736672b9f70ad07aeece55bfd03952012) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50059017)</sub>

<!-- /greptile_comment -->