### PR TITLE
feat: role and permission management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,45 @@ powered by the robust `discord.py-self` library.
 | **interactions** | 3 | send_slash_command, click_button, select_menu |
 | **threads** | 5 | create_thread, send_thread_message, list_active_threads, read_thread_messages, archive_thread |
 | **members** | 5 | kick_member, ban_member, unban_member, add_role, remove_role |
+| **roles** | 6 | list_roles, get_role, create_role, edit_role, delete_role, reorder_roles |
+| **permissions** | 7 | set_role_permissions, get_channel_permissions, set_channel_permissions, patch_channel_permissions, remove_channel_permissions, set_category_permissions, inspect_effective_permissions |
 | **invites** | 3 | create_invite, list_invites, delete_invite |
 | **profile** | 1 | edit_profile |
 | **reactions** | 2 | add_reaction, remove_reaction |
 | **discrawl** | 7 | run_discrawl, discrawl_doctor, discrawl_status, discrawl_sync, discrawl_search, discrawl_messages, discrawl_mentions |
+
+### roles and permissions
+
+`list_roles` returns every role as JSON (id, name, color, position, permission
+bitfield) sorted highest-first. Run it before any restructuring — `position` is
+guild-wide, so moving one role reindexes the others and the dump is your only
+way back.
+
+`create_role` and `edit_role` take `color` as a hex string (`#5865F2`) or an
+integer, and `permissions` as either a raw bitfield string or a list of flag
+names (`["manage_roles", "kick_members"]`). `edit_role` only touches the fields
+you pass. `reorder_roles` moves several roles in one call and falls back to
+sequential edits when the bulk endpoint is unavailable.
+
+Role edits are bounded by hierarchy: your account cannot change a role at or
+above your own highest role. Discord answers that with a bare 403, so these
+tools check position locally first and say which role is blocking. Guild owners
+are exempt.
+
+`set_channel_permissions` replaces an overwrite wholesale, so any flag you do
+not pass is lost. When an overwrite already exists and you only mean to change
+one flag, use `patch_channel_permissions` — it takes a map of flag to
+true/false/null and leaves everything else in that entry untouched.
+
+For channel access, `set_channel_permissions` writes one overwrite and
+`set_category_permissions` writes the category plus, by default, every channel
+inside it (`sync_children: false` to skip). `inspect_effective_permissions`
+resolves a role or member against every channel and reports what they can
+actually see — useful for checking a change landed the way you meant.
+
+Flag names are accepted in either spelling on input, but the `allowed` /
+`denied` lists in JSON output use discord.py-self's canonical names — so
+`view_channel` comes back as `read_messages`.
 
 ### direct messages
 
@@ -373,11 +408,13 @@ discord_py_self_mcp/
     ├── invites.py
     ├── members.py
     ├── messages.py
+    ├── permissions.py
     ├── presence.py
     ├── profile.py
     ├── reactions.py
     ├── registry.py
     ├── relationships.py
+    ├── roles.py
     ├── threads.py
     └── voice.py
 ```

--- a/README.md
+++ b/README.md
@@ -218,7 +218,15 @@ are exempt.
 `set_channel_permissions` replaces an overwrite wholesale, so any flag you do
 not pass is lost. When an overwrite already exists and you only mean to change
 one flag, use `patch_channel_permissions` — it takes a map of flag to
-true/false/null and leaves everything else in that entry untouched.
+true/false/null and leaves everything else in that entry untouched. Because a
+wholesale write with neither `allow` nor `deny` would quietly wipe the entry,
+both setters require at least one of the two and reject a flag listed in both;
+`remove_channel_permissions` is the way to drop an overwrite on purpose.
+
+Role moves are checked twice before anything is sent: the role must sit below
+your own highest role, and so must the position you are moving it to. Both are
+compared with discord's own role ordering rather than raw position numbers,
+since positions can tie and are broken by id.
 
 For channel access, `set_channel_permissions` writes one overwrite and
 `set_category_permissions` writes the category plus, by default, every channel

--- a/discord_py_self_mcp/tools/__init__.py
+++ b/discord_py_self_mcp/tools/__init__.py
@@ -10,6 +10,8 @@ from . import interactions as interactions
 from . import threads as threads
 from . import reactions as reactions
 from . import members as members
+from . import roles as roles
+from . import permissions as permissions
 from . import invites as invites
 from . import profile as profile
 from . import discrawl as discrawl

--- a/discord_py_self_mcp/tools/permissions.py
+++ b/discord_py_self_mcp/tools/permissions.py
@@ -26,21 +26,51 @@ def _resolve_target(guild, target_id: str, target_type: str):
 def _build_overwrite(arguments: dict):
     allow = _parse_permissions(arguments.get("allow"))
     deny = _parse_permissions(arguments.get("deny"))
-    return discord.PermissionOverwrite.from_pair(
-        allow if allow is not None else discord.Permissions.none(),
-        deny if deny is not None else discord.Permissions.none(),
-    )
+
+    if allow is None and deny is None:
+        # An all-neutral overwrite is written as allow=0/deny=0, which wipes whatever
+        # the entry held. Silently destroying an overwrite is not a plausible reading
+        # of "set permissions", and remove_channel_permissions already does it on
+        # purpose.
+        raise ValueError(
+            "Pass allow and/or deny. An overwrite with neither would clear the "
+            "existing entry — use remove_channel_permissions if that is the intent."
+        )
+
+    allow = allow if allow is not None else discord.Permissions.none()
+    deny = deny if deny is not None else discord.Permissions.none()
+
+    # from_pair applies deny second, so a flag in both would be denied without a word.
+    conflicting = sorted(name for name, value in allow if value and getattr(deny, name))
+    if conflicting:
+        raise ValueError(
+            f"These flags are in both allow and deny: {', '.join(conflicting)}. "
+            "Pick one side per flag."
+        )
+
+    return discord.PermissionOverwrite.from_pair(allow, deny)
 
 
 def _overwrite_rows(channel) -> list[dict]:
     rows = []
     for target, overwrite in channel.overwrites.items():
         allow, deny = overwrite.pair()
+
+        # When the role or member is missing from cache, discord.py puts a bare
+        # Object here — it carries an id and nothing else, so asking for .name
+        # would blow up the whole listing.
+        if isinstance(target, discord.Role):
+            target_type = "role"
+        elif isinstance(target, discord.Object):
+            target_type = "unresolved"
+        else:
+            target_type = "member"
+
         rows.append(
             {
                 "target_id": str(target.id),
-                "target_type": "role" if isinstance(target, discord.Role) else "member",
-                "target_name": target.name,
+                "target_type": target_type,
+                "target_name": getattr(target, "name", None),
                 "allow": str(allow.value),
                 "deny": str(deny.value),
                 "allowed": sorted(name for name, value in allow if value),
@@ -131,7 +161,10 @@ async def get_channel_permissions(arguments: dict):
     name="set_channel_permissions",
     description=(
         "Set the permission overwrite for a role or member on one channel. "
-        "allow/deny take a bitfield string or a list of flag names."
+        "allow/deny take a bitfield string or a list of flag names. At least one of "
+        "the two is required, and a flag may not appear in both. To drop an overwrite "
+        "entirely use remove_channel_permissions; to change one flag and keep the "
+        "rest use patch_channel_permissions."
     ),
     input_schema={
         "type": "object",
@@ -312,7 +345,8 @@ async def remove_channel_permissions(arguments: dict):
     description=(
         "Set a permission overwrite on a category. By default the same overwrite is "
         "pushed to every channel inside it — set sync_children to false to touch only "
-        "the category."
+        "the category. At least one of allow/deny is required, and a flag may not "
+        "appear in both."
     ),
     input_schema={
         "type": "object",

--- a/discord_py_self_mcp/tools/permissions.py
+++ b/discord_py_self_mcp/tools/permissions.py
@@ -366,11 +366,12 @@ async def set_category_permissions(arguments: dict):
             for child in category.channels:
                 await apply_rate_limit("action")
                 await child.set_permissions(target, overwrite=overwrite, **reason_kwargs)
-                synced.append(child.name)
+                synced.append((child.name, child.id))
 
         text = f"Set permissions for {target.name} on category {category.name}"
         if synced:
-            text += f" and synced {len(synced)} channel(s): {', '.join(synced)}"
+            names = ", ".join(name for name, _ in synced)
+            text += f" and synced {len(synced)} channel(s): {names}"
         return [TextContent(type="text", text=text)]
     except Exception as e:
         text = f"Error setting category permissions: {str(e)}"
@@ -380,7 +381,10 @@ async def set_category_permissions(arguments: dict):
                 "were synced before this failed"
             )
             if synced:
-                text += f": {', '.join(synced)}"
+                # Ids, not just names: channel names are not unique within a
+                # category, and this list exists to be reconciled against.
+                done = ", ".join(f"{name} ({cid})" for name, cid in synced)
+                text += f": {done}"
             text += ". The remaining channels still have their previous overwrite."
         else:
             text += " — nothing was changed"

--- a/discord_py_self_mcp/tools/permissions.py
+++ b/discord_py_self_mcp/tools/permissions.py
@@ -1,0 +1,434 @@
+import json
+
+import discord
+from mcp.types import TextContent
+
+from ..bot import client
+from ..tool_utils import apply_rate_limit
+from .registry import registry
+from .roles import _hierarchy_block, _parse_permissions
+
+
+def _resolve_target(guild, target_id: str, target_type: str):
+    """Return ``(target, error_text)`` for a role or member id."""
+    if target_type == "role":
+        target = guild.get_role(int(target_id))
+    elif target_type == "member":
+        target = guild.get_member(int(target_id))
+    else:
+        return None, f"Invalid target_type '{target_type}' — use 'role' or 'member'"
+
+    if not target:
+        return None, f"{target_type.capitalize()} {target_id} not found"
+    return target, None
+
+
+def _build_overwrite(arguments: dict):
+    allow = _parse_permissions(arguments.get("allow"))
+    deny = _parse_permissions(arguments.get("deny"))
+    return discord.PermissionOverwrite.from_pair(
+        allow if allow is not None else discord.Permissions.none(),
+        deny if deny is not None else discord.Permissions.none(),
+    )
+
+
+def _overwrite_rows(channel) -> list[dict]:
+    rows = []
+    for target, overwrite in channel.overwrites.items():
+        allow, deny = overwrite.pair()
+        rows.append(
+            {
+                "target_id": str(target.id),
+                "target_type": "role" if isinstance(target, discord.Role) else "member",
+                "target_name": target.name,
+                "allow": str(allow.value),
+                "deny": str(deny.value),
+                "allowed": sorted(name for name, value in allow if value),
+                "denied": sorted(name for name, value in deny if value),
+            }
+        )
+    return rows
+
+
+@registry.register(
+    name="set_role_permissions",
+    description=(
+        "Replace a role's guild-wide permission set. Accepts a bitfield string or a "
+        "list of flag names like [\"manage_roles\", \"kick_members\"]."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "guild_id": {"type": "string"},
+            "role_id": {"type": "string"},
+            "permissions": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}}
+                ]
+            },
+            "reason": {"type": "string"}
+        },
+        "required": ["guild_id", "role_id", "permissions"]
+    }
+)
+async def set_role_permissions(arguments: dict):
+    try:
+        guild = client.get_guild(int(arguments["guild_id"]))
+        if not guild:
+            return [TextContent(type="text", text="Guild not found")]
+
+        role = guild.get_role(int(arguments["role_id"]))
+        if not role:
+            return [TextContent(type="text", text="Role not found")]
+
+        blocked = _hierarchy_block(guild, role)
+        if blocked:
+            return [TextContent(type="text", text=blocked)]
+
+        permissions = _parse_permissions(arguments["permissions"])
+
+        kwargs = {"permissions": permissions}
+        reason = arguments.get("reason")
+        if reason:
+            kwargs["reason"] = reason
+
+        await apply_rate_limit("action")
+        await role.edit(**kwargs)
+        return [
+            TextContent(
+                type="text",
+                text=f"Set permissions on role {role.name} to {permissions.value}",
+            )
+        ]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error setting role permissions: {str(e)}")]
+
+
+@registry.register(
+    name="get_channel_permissions",
+    description="List the permission overwrites on a channel or category as JSON",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "channel_id": {"type": "string"}
+        },
+        "required": ["channel_id"]
+    }
+)
+async def get_channel_permissions(arguments: dict):
+    try:
+        channel = client.get_channel(int(arguments["channel_id"]))
+        if not channel:
+            return [TextContent(type="text", text="Channel not found")]
+
+        return [TextContent(type="text", text=json.dumps(_overwrite_rows(channel), indent=2))]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error getting channel permissions: {str(e)}")]
+
+
+@registry.register(
+    name="set_channel_permissions",
+    description=(
+        "Set the permission overwrite for a role or member on one channel. "
+        "allow/deny take a bitfield string or a list of flag names."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "channel_id": {"type": "string"},
+            "target_id": {"type": "string"},
+            "target_type": {"type": "string", "enum": ["role", "member"]},
+            "allow": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}}
+                ]
+            },
+            "deny": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}}
+                ]
+            },
+            "reason": {"type": "string"}
+        },
+        "required": ["channel_id", "target_id", "target_type"]
+    }
+)
+async def set_channel_permissions(arguments: dict):
+    try:
+        channel = client.get_channel(int(arguments["channel_id"]))
+        if not channel:
+            return [TextContent(type="text", text="Channel not found")]
+
+        target, error = _resolve_target(
+            channel.guild, arguments["target_id"], arguments["target_type"]
+        )
+        if error:
+            return [TextContent(type="text", text=error)]
+
+        overwrite = _build_overwrite(arguments)
+        reason = arguments.get("reason")
+
+        await apply_rate_limit("action")
+        if reason:
+            await channel.set_permissions(target, overwrite=overwrite, reason=reason)
+        else:
+            await channel.set_permissions(target, overwrite=overwrite)
+
+        return [
+            TextContent(
+                type="text",
+                text=f"Set permissions for {target.name} on #{channel.name}",
+            )
+        ]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error setting channel permissions: {str(e)}")]
+
+
+@registry.register(
+    name="patch_channel_permissions",
+    description=(
+        "Change individual permission flags on a channel overwrite and leave the rest "
+        "of that overwrite alone. Prefer this over set_channel_permissions whenever an "
+        "overwrite already exists — set_channel_permissions replaces the whole entry, "
+        "so untouched flags would be lost."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "channel_id": {"type": "string"},
+            "target_id": {"type": "string"},
+            "target_type": {"type": "string", "enum": ["role", "member"]},
+            "set": {
+                "type": "object",
+                "description": (
+                    "Flag name to true (allow), false (deny) or null (inherit). "
+                    "Only the flags listed here change."
+                ),
+                "additionalProperties": {"type": ["boolean", "null"]}
+            },
+            "reason": {"type": "string"}
+        },
+        "required": ["channel_id", "target_id", "target_type", "set"]
+    }
+)
+async def patch_channel_permissions(arguments: dict):
+    try:
+        channel = client.get_channel(int(arguments["channel_id"]))
+        if not channel:
+            return [TextContent(type="text", text="Channel not found")]
+
+        target, error = _resolve_target(
+            channel.guild, arguments["target_id"], arguments["target_type"]
+        )
+        if error:
+            return [TextContent(type="text", text=error)]
+
+        changes = arguments.get("set") or {}
+        if not changes:
+            return [TextContent(type="text", text="Nothing to change — 'set' is empty")]
+
+        valid = getattr(discord.PermissionOverwrite, "VALID_NAMES", None)
+        unknown = [name for name in changes if valid and name not in valid]
+        if unknown:
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Unknown permission name(s): {', '.join(unknown)}",
+                )
+            ]
+
+        overwrite = channel.overwrites.get(target) or discord.PermissionOverwrite()
+        for name, value in changes.items():
+            setattr(overwrite, name, value)
+
+        reason = arguments.get("reason")
+
+        await apply_rate_limit("action")
+        if reason:
+            await channel.set_permissions(target, overwrite=overwrite, reason=reason)
+        else:
+            await channel.set_permissions(target, overwrite=overwrite)
+
+        summary = ", ".join(f"{name}={value}" for name, value in changes.items())
+        return [
+            TextContent(
+                type="text",
+                text=f"Patched {target.name} on #{channel.name}: {summary}",
+            )
+        ]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error patching channel permissions: {str(e)}")]
+
+
+@registry.register(
+    name="remove_channel_permissions",
+    description="Clear a role's or member's permission overwrite on a channel",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "channel_id": {"type": "string"},
+            "target_id": {"type": "string"},
+            "target_type": {"type": "string", "enum": ["role", "member"]},
+            "reason": {"type": "string"}
+        },
+        "required": ["channel_id", "target_id", "target_type"]
+    }
+)
+async def remove_channel_permissions(arguments: dict):
+    try:
+        channel = client.get_channel(int(arguments["channel_id"]))
+        if not channel:
+            return [TextContent(type="text", text="Channel not found")]
+
+        target, error = _resolve_target(
+            channel.guild, arguments["target_id"], arguments["target_type"]
+        )
+        if error:
+            return [TextContent(type="text", text=error)]
+
+        reason = arguments.get("reason")
+
+        await apply_rate_limit("action")
+        if reason:
+            await channel.set_permissions(target, overwrite=None, reason=reason)
+        else:
+            await channel.set_permissions(target, overwrite=None)
+
+        return [
+            TextContent(
+                type="text",
+                text=f"Removed permission overwrite for {target.name} on #{channel.name}",
+            )
+        ]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error removing channel permissions: {str(e)}")]
+
+
+@registry.register(
+    name="set_category_permissions",
+    description=(
+        "Set a permission overwrite on a category. By default the same overwrite is "
+        "pushed to every channel inside it — set sync_children to false to touch only "
+        "the category."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "category_id": {"type": "string"},
+            "target_id": {"type": "string"},
+            "target_type": {"type": "string", "enum": ["role", "member"]},
+            "allow": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}}
+                ]
+            },
+            "deny": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}}
+                ]
+            },
+            "sync_children": {"type": "boolean", "default": True},
+            "reason": {"type": "string"}
+        },
+        "required": ["category_id", "target_id", "target_type"]
+    }
+)
+async def set_category_permissions(arguments: dict):
+    try:
+        category = client.get_channel(int(arguments["category_id"]))
+        if not category or not isinstance(category, discord.CategoryChannel):
+            return [TextContent(type="text", text="Category not found")]
+
+        target, error = _resolve_target(
+            category.guild, arguments["target_id"], arguments["target_type"]
+        )
+        if error:
+            return [TextContent(type="text", text=error)]
+
+        overwrite = _build_overwrite(arguments)
+
+        await apply_rate_limit("action")
+        await category.set_permissions(target, overwrite=overwrite)
+
+        synced = []
+        if arguments.get("sync_children", True):
+            for child in category.channels:
+                await apply_rate_limit("action")
+                await child.set_permissions(target, overwrite=overwrite)
+                synced.append(child.name)
+
+        text = f"Set permissions for {target.name} on category {category.name}"
+        if synced:
+            text += f" and synced {len(synced)} channel(s): {', '.join(synced)}"
+        return [TextContent(type="text", text=text)]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error setting category permissions: {str(e)}")]
+
+
+@registry.register(
+    name="inspect_effective_permissions",
+    description=(
+        "Show what a role or member can actually do: guild-wide permissions plus which "
+        "channels they can and cannot see once overwrites are applied. Returns JSON."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "guild_id": {"type": "string"},
+            "target_id": {"type": "string"},
+            "target_type": {"type": "string", "enum": ["role", "member"]},
+            "channel_limit": {
+                "type": "integer",
+                "default": 25,
+                "description": "How many channel names to list per bucket"
+            }
+        },
+        "required": ["guild_id", "target_id", "target_type"]
+    }
+)
+async def inspect_effective_permissions(arguments: dict):
+    try:
+        guild = client.get_guild(int(arguments["guild_id"]))
+        if not guild:
+            return [TextContent(type="text", text="Guild not found")]
+
+        target, error = _resolve_target(
+            guild, arguments["target_id"], arguments["target_type"]
+        )
+        if error:
+            return [TextContent(type="text", text=error)]
+
+        limit = int(arguments.get("channel_limit", 25))
+
+        guild_permissions = (
+            target.permissions
+            if isinstance(target, discord.Role)
+            else target.guild_permissions
+        )
+
+        accessible = []
+        hidden = []
+        for channel in guild.channels:
+            bucket = accessible if channel.permissions_for(target).view_channel else hidden
+            bucket.append(channel.name)
+
+        payload = {
+            "target_id": str(target.id),
+            "target_type": arguments["target_type"],
+            "target_name": target.name,
+            "guild_permissions": str(guild_permissions.value),
+            "granted": sorted(name for name, value in guild_permissions if value),
+            "is_administrator": guild_permissions.administrator,
+            "accessible_channel_count": len(accessible),
+            "hidden_channel_count": len(hidden),
+            "accessible_channels": sorted(accessible)[:limit],
+            "hidden_channels": sorted(hidden)[:limit],
+        }
+        return [TextContent(type="text", text=json.dumps(payload, indent=2))]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error inspecting permissions: {str(e)}")]

--- a/discord_py_self_mcp/tools/permissions.py
+++ b/discord_py_self_mcp/tools/permissions.py
@@ -339,6 +339,10 @@ async def remove_channel_permissions(arguments: dict):
     }
 )
 async def set_category_permissions(arguments: dict):
+    # Tracked outside the try: a failure part-way through the children still leaves
+    # everything before it changed, and the caller needs to know how far it got.
+    category_done = False
+    synced = []
     try:
         category = client.get_channel(int(arguments["category_id"]))
         if not category or not isinstance(category, discord.CategoryChannel):
@@ -351,15 +355,17 @@ async def set_category_permissions(arguments: dict):
             return [TextContent(type="text", text=error)]
 
         overwrite = _build_overwrite(arguments)
+        reason = arguments.get("reason")
+        reason_kwargs = {"reason": reason} if reason else {}
 
         await apply_rate_limit("action")
-        await category.set_permissions(target, overwrite=overwrite)
+        await category.set_permissions(target, overwrite=overwrite, **reason_kwargs)
+        category_done = True
 
-        synced = []
         if arguments.get("sync_children", True):
             for child in category.channels:
                 await apply_rate_limit("action")
-                await child.set_permissions(target, overwrite=overwrite)
+                await child.set_permissions(target, overwrite=overwrite, **reason_kwargs)
                 synced.append(child.name)
 
         text = f"Set permissions for {target.name} on category {category.name}"
@@ -367,7 +373,18 @@ async def set_category_permissions(arguments: dict):
             text += f" and synced {len(synced)} channel(s): {', '.join(synced)}"
         return [TextContent(type="text", text=text)]
     except Exception as e:
-        return [TextContent(type="text", text=f"Error setting category permissions: {str(e)}")]
+        text = f"Error setting category permissions: {str(e)}"
+        if category_done:
+            text += (
+                f" — the category was already updated and {len(synced)} channel(s) "
+                "were synced before this failed"
+            )
+            if synced:
+                text += f": {', '.join(synced)}"
+            text += ". The remaining channels still have their previous overwrite."
+        else:
+            text += " — nothing was changed"
+        return [TextContent(type="text", text=text)]
 
 
 @registry.register(

--- a/discord_py_self_mcp/tools/roles.py
+++ b/discord_py_self_mcp/tools/roles.py
@@ -87,6 +87,32 @@ def _hierarchy_block(guild, role) -> str | None:
     return None
 
 
+def _position_block(guild, position) -> str | None:
+    """Reject a move to a rank the account cannot reach.
+
+    _hierarchy_block only covers where a role is now. Both write paths also take a
+    destination, and Discord answers an out-of-reach destination with the same bare
+    Forbidden this module exists to translate.
+    """
+    me = getattr(guild, "me", None)
+    if me is None:
+        return None
+    if getattr(guild, "owner_id", None) == getattr(me, "id", None):
+        return None
+
+    top_role = getattr(me, "top_role", None)
+    if top_role is None:
+        return None
+
+    if position >= top_role.position:
+        return (
+            f"Position {position} is at or above your highest role '{top_role.name}' "
+            f"(position {top_role.position}). Discord refuses moves to a position "
+            "that is not below your own."
+        )
+    return None
+
+
 @registry.register(
     name="list_roles",
     description=(
@@ -249,6 +275,11 @@ async def edit_role(arguments: dict):
         if blocked:
             return [TextContent(type="text", text=blocked)]
 
+        if arguments.get("position") is not None:
+            blocked = _position_block(guild, int(arguments["position"]))
+            if blocked:
+                return [TextContent(type="text", text=blocked)]
+
         kwargs = {}
         for field in ("name", "position", "hoist", "mentionable"):
             if arguments.get(field) is not None:
@@ -345,6 +376,9 @@ async def delete_role(arguments: dict):
     }
 )
 async def reorder_roles(arguments: dict):
+    # Tracked outside the try: the sequential fallback commits one role at a time,
+    # so a failure part-way leaves earlier moves applied.
+    applied = []
     try:
         guild = client.get_guild(int(arguments["guild_id"]))
         if not guild:
@@ -364,7 +398,14 @@ async def reorder_roles(arguments: dict):
             if blocked:
                 return [TextContent(type="text", text=blocked)]
 
-            resolved[role] = int(entry["position"])
+            position = int(entry["position"])
+            # Validate every destination before sending anything, so a rejected move
+            # cannot abort the sequential fallback half way through the batch.
+            blocked = _position_block(guild, position)
+            if blocked:
+                return [TextContent(type="text", text=f"{role.name}: {blocked}")]
+
+            resolved[role] = position
 
         reason = arguments.get("reason")
 
@@ -389,6 +430,7 @@ async def reorder_roles(arguments: dict):
                 if reason:
                     kwargs["reason"] = reason
                 result = await role.edit(**kwargs)
+                applied.append(f"{role.name} ({role.id})")
                 if result is not None:
                     updated[result.id] = result
 
@@ -404,4 +446,12 @@ async def reorder_roles(arguments: dict):
         )
         return [TextContent(type="text", text=f"Reordered {len(resolved)} role(s). {landed}")]
     except Exception as e:
-        return [TextContent(type="text", text=f"Error reordering roles: {str(e)}")]
+        text = f"Error reordering roles: {str(e)}"
+        if applied:
+            # Ids as well as names: role names are not unique either, and this list
+            # exists to be reconciled against.
+            text += (
+                f" — {len(applied)} role(s) were already moved before this failed: "
+                f"{', '.join(applied)}. The rest were not touched."
+            )
+        return [TextContent(type="text", text=text)]

--- a/discord_py_self_mcp/tools/roles.py
+++ b/discord_py_self_mcp/tools/roles.py
@@ -75,7 +75,10 @@ def _hierarchy_block(guild, role) -> str | None:
     if top_role is None:
         return None
 
-    if role.position >= top_role.position:
+    # Compare the roles themselves, not their positions: Discord allows two roles
+    # to share a position and breaks the tie by id, and @everyone is always lowest.
+    # Role.__lt__ already encodes both rules.
+    if role >= top_role:
         return (
             f"Role '{role.name}' (position {role.position}) is at or above your highest "
             f"role '{top_role.name}' (position {top_role.position}). Discord refuses "
@@ -369,11 +372,22 @@ async def reorder_roles(arguments: dict):
         if hasattr(guild, "edit_role_positions"):
             await guild.edit_role_positions(positions=resolved, reason=reason)
         else:
-            # Older discord.py-self builds have no bulk endpoint wrapper.
-            for role, position in resolved.items():
-                await role.edit(position=position)
+            # Older discord.py-self builds have no bulk endpoint wrapper. Each edit
+            # reindexes the roles around it, so the batch cannot be applied
+            # atomically; going top-down keeps it deterministic, and the caller is
+            # told to read the resulting positions rather than assume them.
+            for role, position in sorted(resolved.items(), key=lambda kv: -kv[1]):
+                kwargs = {"position": position}
+                if reason:
+                    kwargs["reason"] = reason
+                await role.edit(**kwargs)
 
-        moved = ", ".join(f"{role.name}->{position}" for role, position in resolved.items())
-        return [TextContent(type="text", text=f"Reordered {len(resolved)} role(s): {moved}")]
+        # Report where the roles actually landed. A batch move reindexes every role
+        # in between, so the result routinely differs from what was requested.
+        landed = ", ".join(
+            f"{role.name}: asked {position}, now {role.position}"
+            for role, position in sorted(resolved.items(), key=lambda kv: -kv[1])
+        )
+        return [TextContent(type="text", text=f"Reordered {len(resolved)} role(s). {landed}")]
     except Exception as e:
         return [TextContent(type="text", text=f"Error reordering roles: {str(e)}")]

--- a/discord_py_self_mcp/tools/roles.py
+++ b/discord_py_self_mcp/tools/roles.py
@@ -1,0 +1,379 @@
+import json
+
+import discord
+from mcp.types import TextContent
+
+from ..bot import client
+from ..tool_utils import apply_rate_limit
+from .registry import registry
+
+
+def _role_payload(role) -> dict:
+    return {
+        "id": str(role.id),
+        "name": role.name,
+        "color": f"#{role.color.value:06X}",
+        "color_value": role.color.value,
+        "hoist": role.hoist,
+        "position": role.position,
+        "permissions": str(role.permissions.value),
+        "managed": role.managed,
+        "mentionable": role.mentionable,
+    }
+
+
+def _parse_color(raw):
+    """Accept ``"#5865F2"``/``"5865F2"``/``"0x5865F2"`` as hex, plain ints as decimal."""
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        raise ValueError("color must be a hex string or an integer")
+    if isinstance(raw, int):
+        return discord.Color(raw)
+
+    text = str(raw).strip().lstrip("#")
+    if text.lower().startswith("0x"):
+        text = text[2:]
+    try:
+        return discord.Color(int(text, 16))
+    except ValueError:
+        raise ValueError(f"Invalid color '{raw}'. Use a hex string like #5865F2.")
+
+
+def _parse_permissions(raw):
+    """Accept either a raw bitfield or a list of ``discord.Permissions`` flag names."""
+    if raw is None:
+        return None
+    if isinstance(raw, list):
+        # Permissions.update() drops unknown keys silently, so validate up front.
+        valid_flags = getattr(discord.Permissions, "VALID_FLAGS", {})
+        unknown = [name for name in raw if valid_flags and name not in valid_flags]
+        if unknown:
+            raise ValueError(
+                f"Unknown permission name(s): {', '.join(unknown)}. "
+                "Use names like manage_roles, send_messages, view_channel."
+            )
+        perms = discord.Permissions()
+        perms.update(**{name: True for name in raw})
+        return perms
+    return discord.Permissions(int(raw))
+
+
+def _hierarchy_block(guild, role) -> str | None:
+    """Explain an unavoidable 403 before spending the request on it.
+
+    Discord answers "role above yours" with a bare Forbidden, which reads like a
+    bug. The position comparison is local and says exactly what is wrong.
+    """
+    me = getattr(guild, "me", None)
+    if me is None:
+        return None
+    if getattr(guild, "owner_id", None) == getattr(me, "id", None):
+        return None
+
+    top_role = getattr(me, "top_role", None)
+    if top_role is None:
+        return None
+
+    if role.position >= top_role.position:
+        return (
+            f"Role '{role.name}' (position {role.position}) is at or above your highest "
+            f"role '{top_role.name}' (position {top_role.position}). Discord refuses "
+            "edits to roles that are not below your own — ask for a higher role first."
+        )
+    return None
+
+
+@registry.register(
+    name="list_roles",
+    description=(
+        "List every role in a guild with id, name, color, position and permission "
+        "bitfield. Returns JSON — use it to snapshot the current setup before "
+        "reordering anything."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "guild_id": {"type": "string"}
+        },
+        "required": ["guild_id"]
+    }
+)
+async def list_roles(arguments: dict):
+    try:
+        guild = client.get_guild(int(arguments["guild_id"]))
+        if not guild:
+            return [TextContent(type="text", text="Guild not found")]
+
+        roles = sorted(guild.roles, key=lambda r: r.position, reverse=True)
+        payload = [_role_payload(role) for role in roles]
+        return [TextContent(type="text", text=json.dumps(payload, indent=2))]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error listing roles: {str(e)}")]
+
+
+@registry.register(
+    name="get_role",
+    description="Get a single role's full details as JSON",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "guild_id": {"type": "string"},
+            "role_id": {"type": "string"}
+        },
+        "required": ["guild_id", "role_id"]
+    }
+)
+async def get_role(arguments: dict):
+    try:
+        guild = client.get_guild(int(arguments["guild_id"]))
+        if not guild:
+            return [TextContent(type="text", text="Guild not found")]
+
+        role = guild.get_role(int(arguments["role_id"]))
+        if not role:
+            return [TextContent(type="text", text="Role not found")]
+
+        return [TextContent(type="text", text=json.dumps(_role_payload(role), indent=2))]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error getting role: {str(e)}")]
+
+
+@registry.register(
+    name="create_role",
+    description="Create a role in a guild",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "guild_id": {"type": "string"},
+            "name": {"type": "string"},
+            "color": {
+                "anyOf": [{"type": "string"}, {"type": "integer"}],
+                "description": "Hex string like #5865F2, or an integer color value"
+            },
+            "permissions": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}}
+                ],
+                "description": "Permission bitfield as a string, or a list of flag names like [\"manage_roles\"]"
+            },
+            "hoist": {"type": "boolean", "default": False},
+            "mentionable": {"type": "boolean", "default": False},
+            "reason": {"type": "string"}
+        },
+        "required": ["guild_id", "name"]
+    }
+)
+async def create_role(arguments: dict):
+    try:
+        guild = client.get_guild(int(arguments["guild_id"]))
+        if not guild:
+            return [TextContent(type="text", text="Guild not found")]
+
+        kwargs = {
+            "name": arguments["name"],
+            "hoist": arguments.get("hoist", False),
+            "mentionable": arguments.get("mentionable", False),
+        }
+
+        color = _parse_color(arguments.get("color"))
+        if color is not None:
+            kwargs["color"] = color
+
+        permissions = _parse_permissions(arguments.get("permissions"))
+        if permissions is not None:
+            kwargs["permissions"] = permissions
+
+        reason = arguments.get("reason")
+        if reason:
+            kwargs["reason"] = reason
+
+        await apply_rate_limit("action")
+        role = await guild.create_role(**kwargs)
+        return [
+            TextContent(
+                type="text",
+                text=f"Created role {role.name} ({role.id}) at position {role.position}",
+            )
+        ]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error creating role: {str(e)}")]
+
+
+@registry.register(
+    name="edit_role",
+    description=(
+        "Edit a role's name, color, permissions, position, hoist or mentionable flag. "
+        "Only the fields you pass are changed."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "guild_id": {"type": "string"},
+            "role_id": {"type": "string"},
+            "name": {"type": "string"},
+            "color": {
+                "anyOf": [{"type": "string"}, {"type": "integer"}],
+                "description": "Hex string like #5865F2, or an integer color value"
+            },
+            "permissions": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}}
+                ],
+                "description": "Permission bitfield as a string, or a list of flag names. Replaces the whole set."
+            },
+            "position": {"type": "integer"},
+            "hoist": {"type": "boolean"},
+            "mentionable": {"type": "boolean"},
+            "reason": {"type": "string"}
+        },
+        "required": ["guild_id", "role_id"]
+    }
+)
+async def edit_role(arguments: dict):
+    try:
+        guild = client.get_guild(int(arguments["guild_id"]))
+        if not guild:
+            return [TextContent(type="text", text="Guild not found")]
+
+        role = guild.get_role(int(arguments["role_id"]))
+        if not role:
+            return [TextContent(type="text", text="Role not found")]
+
+        blocked = _hierarchy_block(guild, role)
+        if blocked:
+            return [TextContent(type="text", text=blocked)]
+
+        kwargs = {}
+        for field in ("name", "position", "hoist", "mentionable"):
+            if arguments.get(field) is not None:
+                kwargs[field] = arguments[field]
+
+        color = _parse_color(arguments.get("color"))
+        if color is not None:
+            kwargs["color"] = color
+
+        permissions = _parse_permissions(arguments.get("permissions"))
+        if permissions is not None:
+            kwargs["permissions"] = permissions
+
+        if not kwargs:
+            return [TextContent(type="text", text="Nothing to change — pass at least one field")]
+
+        reason = arguments.get("reason")
+        if reason:
+            kwargs["reason"] = reason
+
+        await apply_rate_limit("action")
+        await role.edit(**kwargs)
+
+        changed = ", ".join(sorted(field for field in kwargs if field != "reason"))
+        return [TextContent(type="text", text=f"Edited role {role.name} ({changed})")]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error editing role: {str(e)}")]
+
+
+@registry.register(
+    name="delete_role",
+    description="Delete a role from a guild. This cannot be undone.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "guild_id": {"type": "string"},
+            "role_id": {"type": "string"},
+            "reason": {"type": "string"}
+        },
+        "required": ["guild_id", "role_id"]
+    }
+)
+async def delete_role(arguments: dict):
+    try:
+        guild = client.get_guild(int(arguments["guild_id"]))
+        if not guild:
+            return [TextContent(type="text", text="Guild not found")]
+
+        role = guild.get_role(int(arguments["role_id"]))
+        if not role:
+            return [TextContent(type="text", text="Role not found")]
+
+        blocked = _hierarchy_block(guild, role)
+        if blocked:
+            return [TextContent(type="text", text=blocked)]
+
+        role_name = role.name
+        reason = arguments.get("reason")
+
+        await apply_rate_limit("action")
+        if reason:
+            await role.delete(reason=reason)
+        else:
+            await role.delete()
+        return [TextContent(type="text", text=f"Deleted role {role_name}")]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error deleting role: {str(e)}")]
+
+
+@registry.register(
+    name="reorder_roles",
+    description=(
+        "Move several roles to new positions in one call. Position is guild-wide: "
+        "higher number sits higher in the list. Snapshot with list_roles first."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "guild_id": {"type": "string"},
+            "positions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "role_id": {"type": "string"},
+                        "position": {"type": "integer"}
+                    },
+                    "required": ["role_id", "position"]
+                }
+            },
+            "reason": {"type": "string"}
+        },
+        "required": ["guild_id", "positions"]
+    }
+)
+async def reorder_roles(arguments: dict):
+    try:
+        guild = client.get_guild(int(arguments["guild_id"]))
+        if not guild:
+            return [TextContent(type="text", text="Guild not found")]
+
+        entries = arguments.get("positions") or []
+        if not entries:
+            return [TextContent(type="text", text="No positions given")]
+
+        resolved = {}
+        for entry in entries:
+            role = guild.get_role(int(entry["role_id"]))
+            if not role:
+                return [TextContent(type="text", text=f"Role {entry['role_id']} not found")]
+
+            blocked = _hierarchy_block(guild, role)
+            if blocked:
+                return [TextContent(type="text", text=blocked)]
+
+            resolved[role] = int(entry["position"])
+
+        reason = arguments.get("reason")
+
+        await apply_rate_limit("action")
+        if hasattr(guild, "edit_role_positions"):
+            await guild.edit_role_positions(positions=resolved, reason=reason)
+        else:
+            # Older discord.py-self builds have no bulk endpoint wrapper.
+            for role, position in resolved.items():
+                await role.edit(position=position)
+
+        moved = ", ".join(f"{role.name}->{position}" for role, position in resolved.items())
+        return [TextContent(type="text", text=f"Reordered {len(resolved)} role(s): {moved}")]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error reordering roles: {str(e)}")]

--- a/discord_py_self_mcp/tools/roles.py
+++ b/discord_py_self_mcp/tools/roles.py
@@ -368,9 +368,17 @@ async def reorder_roles(arguments: dict):
 
         reason = arguments.get("reason")
 
+        # Neither API mutates the Role objects we hold: edit_role_positions builds
+        # replacements and swaps them into the guild cache, and Role.edit returns a
+        # new instance. Reading position off the originals would report pre-move
+        # values, so collect what the API hands back.
+        updated = {}
+
         await apply_rate_limit("action")
         if hasattr(guild, "edit_role_positions"):
-            await guild.edit_role_positions(positions=resolved, reason=reason)
+            returned = await guild.edit_role_positions(positions=resolved, reason=reason)
+            for role in returned or []:
+                updated[role.id] = role
         else:
             # Older discord.py-self builds have no bulk endpoint wrapper. Each edit
             # reindexes the roles around it, so the batch cannot be applied
@@ -380,12 +388,18 @@ async def reorder_roles(arguments: dict):
                 kwargs = {"position": position}
                 if reason:
                     kwargs["reason"] = reason
-                await role.edit(**kwargs)
+                result = await role.edit(**kwargs)
+                if result is not None:
+                    updated[result.id] = result
+
+        def current_position(role):
+            fresh = updated.get(role.id) or guild.get_role(role.id)
+            return fresh.position if fresh is not None else role.position
 
         # Report where the roles actually landed. A batch move reindexes every role
         # in between, so the result routinely differs from what was requested.
         landed = ", ".join(
-            f"{role.name}: asked {position}, now {role.position}"
+            f"{role.name}: asked {position}, now {current_position(role)}"
             for role, position in sorted(resolved.items(), key=lambda kv: -kv[1])
         )
         return [TextContent(type="text", text=f"Reordered {len(resolved)} role(s). {landed}")]

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -26,6 +26,15 @@ class FakeRole:
         self.permissions = discord.Permissions(0)
         self.edits = []
 
+    # Mirrors discord.Role ordering: equal positions are broken by id.
+    def __lt__(self, other):
+        if self.position == other.position:
+            return self.id > other.id
+        return self.position < other.position
+
+    def __ge__(self, other):
+        return not self < other
+
     async def edit(self, **kwargs):
         self.edits.append(kwargs)
 
@@ -61,10 +70,12 @@ class FakeChannel:
         self.guild = guild
         self.overwrites = overwrites or {}
         self.calls = []
+        self.call_kwargs = []
         self._view = view
 
     async def set_permissions(self, target, overwrite=..., **kwargs):
         self.calls.append((target, overwrite))
+        self.call_kwargs.append(kwargs)
 
     def permissions_for(self, target):
         return discord.Permissions(discord.Permissions.all().value if self._view else 0)
@@ -288,6 +299,67 @@ async def test_set_category_permissions_syncs_children(monkeypatch):
     assert child_a.calls[0][0] is role
     assert child_b.calls[0][0] is role
     assert "synced 2 channel(s): chat, voice" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_set_category_permissions_forwards_reason(monkeypatch):
+    role = FakeRole()
+    guild = FakeGuild(roles_list=[role])
+    child = FakeChannel(name="chat", guild=guild)
+
+    class FakeCategory(FakeChannel):
+        def __init__(self):
+            super().__init__(name="staff", guild=guild)
+            self.channels = [child]
+
+    category = FakeCategory()
+    monkeypatch.setattr(discord, "CategoryChannel", FakeCategory)
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=category))
+
+    await permissions.set_category_permissions(
+        {
+            "category_id": "1",
+            "target_id": "10",
+            "target_type": "role",
+            "deny": ["view_channel"],
+            "reason": "tidying up",
+        }
+    )
+
+    assert category.call_kwargs[0]["reason"] == "tidying up"
+    assert child.call_kwargs[0]["reason"] == "tidying up"
+
+
+@pytest.mark.asyncio
+async def test_set_category_permissions_reports_partial_progress(monkeypatch):
+    role = FakeRole()
+    guild = FakeGuild(roles_list=[role])
+    good = FakeChannel(name="chat", guild=guild)
+
+    class Exploding(FakeChannel):
+        async def set_permissions(self, target, overwrite=..., **kwargs):
+            raise RuntimeError("500 Internal Server Error")
+
+    bad = Exploding(name="voice", guild=guild)
+
+    class FakeCategory(FakeChannel):
+        def __init__(self):
+            super().__init__(name="staff", guild=guild)
+            self.channels = [good, bad]
+
+    category = FakeCategory()
+    monkeypatch.setattr(discord, "CategoryChannel", FakeCategory)
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=category))
+
+    result = await permissions.set_category_permissions(
+        {"category_id": "1", "target_id": "10", "target_type": "role", "deny": ["view_channel"]}
+    )
+
+    text = result[0].text
+    assert "500 Internal Server Error" in text
+    assert "the category was already updated" in text
+    assert "chat" in text
+    assert "still have their previous overwrite" in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,318 @@
+import json
+
+import discord
+import pytest
+
+from discord_py_self_mcp.tools import permissions
+
+
+class FakeClient:
+    def __init__(self, guild=None, channel=None):
+        self._guild = guild
+        self._channel = channel
+
+    def get_guild(self, guild_id):
+        return self._guild
+
+    def get_channel(self, channel_id):
+        return self._channel
+
+
+class FakeRole:
+    def __init__(self, role_id=10, name="mod", position=5):
+        self.id = role_id
+        self.name = name
+        self.position = position
+        self.permissions = discord.Permissions(0)
+        self.edits = []
+
+    async def edit(self, **kwargs):
+        self.edits.append(kwargs)
+
+
+class FakeMe:
+    def __init__(self, top_role):
+        self.id = 999
+        self.top_role = top_role
+
+
+class FakeGuild:
+    def __init__(self, roles_list=None, members=None, channels=None, me=None):
+        self.roles = roles_list or []
+        self._members = members or {}
+        self.channels = channels or []
+        self.me = me
+        self.owner_id = None
+
+    def get_role(self, role_id):
+        for role in self.roles:
+            if role.id == role_id:
+                return role
+        return None
+
+    def get_member(self, user_id):
+        return self._members.get(user_id)
+
+
+class FakeChannel:
+    def __init__(self, name="general", guild=None, overwrites=None, view=True):
+        self.id = 500
+        self.name = name
+        self.guild = guild
+        self.overwrites = overwrites or {}
+        self.calls = []
+        self._view = view
+
+    async def set_permissions(self, target, overwrite=..., **kwargs):
+        self.calls.append((target, overwrite))
+
+    def permissions_for(self, target):
+        return discord.Permissions(discord.Permissions.all().value if self._view else 0)
+
+
+def _guild_with_role(role, my_top_position=100):
+    top = FakeRole(role_id=1, name="admin", position=my_top_position)
+    return FakeGuild(roles_list=[role, top], me=FakeMe(top))
+
+
+@pytest.mark.asyncio
+async def test_set_role_permissions_accepts_flag_names(monkeypatch):
+    role = FakeRole()
+    monkeypatch.setattr(permissions, "client", FakeClient(guild=_guild_with_role(role)))
+
+    result = await permissions.set_role_permissions(
+        {"guild_id": "1", "role_id": "10", "permissions": ["kick_members"]}
+    )
+
+    assert role.edits[0]["permissions"].kick_members is True
+    assert "Set permissions on role mod" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_set_role_permissions_blocks_role_above_own(monkeypatch):
+    role = FakeRole(position=50)
+    guild = _guild_with_role(role, my_top_position=20)
+    monkeypatch.setattr(permissions, "client", FakeClient(guild=guild))
+
+    result = await permissions.set_role_permissions(
+        {"guild_id": "1", "role_id": "10", "permissions": "8"}
+    )
+
+    assert "at or above your highest role" in result[0].text
+    assert role.edits == []
+
+
+@pytest.mark.asyncio
+async def test_set_channel_permissions_builds_overwrite(monkeypatch):
+    role = FakeRole()
+    guild = FakeGuild(roles_list=[role])
+    channel = FakeChannel(guild=guild)
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.set_channel_permissions(
+        {
+            "channel_id": "500",
+            "target_id": "10",
+            "target_type": "role",
+            "allow": ["view_channel"],
+            "deny": ["send_messages"],
+        }
+    )
+
+    target, overwrite = channel.calls[0]
+    assert target is role
+    assert overwrite.view_channel is True
+    assert overwrite.send_messages is False
+    assert "Set permissions for mod on #general" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_set_channel_permissions_rejects_bad_target_type(monkeypatch):
+    channel = FakeChannel(guild=FakeGuild())
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.set_channel_permissions(
+        {"channel_id": "500", "target_id": "10", "target_type": "everyone"}
+    )
+
+    assert "Invalid target_type 'everyone'" in result[0].text
+    assert channel.calls == []
+
+
+@pytest.mark.asyncio
+async def test_patch_channel_permissions_preserves_other_flags(monkeypatch):
+    role = FakeRole()
+    overwrite = discord.PermissionOverwrite()
+    overwrite.view_channel = True
+    overwrite.send_messages = True
+    overwrite.attach_files = True
+    channel = FakeChannel(guild=FakeGuild(roles_list=[role]), overwrites={role: overwrite})
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.patch_channel_permissions(
+        {
+            "channel_id": "500",
+            "target_id": "10",
+            "target_type": "role",
+            "set": {"attach_files": None},
+        }
+    )
+
+    _, written = channel.calls[0]
+    assert written.attach_files is None
+    assert written.view_channel is True
+    assert written.send_messages is True
+    assert "attach_files=None" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_patch_channel_permissions_rejects_unknown_flag(monkeypatch):
+    role = FakeRole()
+    channel = FakeChannel(guild=FakeGuild(roles_list=[role]))
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.patch_channel_permissions(
+        {
+            "channel_id": "500",
+            "target_id": "10",
+            "target_type": "role",
+            "set": {"send_glitter": True},
+        }
+    )
+
+    assert "Unknown permission name(s): send_glitter" in result[0].text
+    assert channel.calls == []
+
+
+@pytest.mark.asyncio
+async def test_patch_channel_permissions_requires_changes(monkeypatch):
+    role = FakeRole()
+    channel = FakeChannel(guild=FakeGuild(roles_list=[role]))
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.patch_channel_permissions(
+        {"channel_id": "500", "target_id": "10", "target_type": "role", "set": {}}
+    )
+
+    assert result[0].text == "Nothing to change — 'set' is empty"
+    assert channel.calls == []
+
+
+@pytest.mark.asyncio
+async def test_remove_channel_permissions_clears_overwrite(monkeypatch):
+    role = FakeRole()
+    channel = FakeChannel(guild=FakeGuild(roles_list=[role]))
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.remove_channel_permissions(
+        {"channel_id": "500", "target_id": "10", "target_type": "role"}
+    )
+
+    assert channel.calls == [(role, None)]
+    assert "Removed permission overwrite for mod" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_get_channel_permissions_lists_allow_and_deny(monkeypatch):
+    role = FakeRole()
+    overwrite = discord.PermissionOverwrite()
+    overwrite.view_channel = True
+    overwrite.send_messages = False
+    channel = FakeChannel(guild=FakeGuild(roles_list=[role]), overwrites={role: overwrite})
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.get_channel_permissions({"channel_id": "500"})
+    payload = json.loads(result[0].text)
+
+    assert payload[0]["target_name"] == "mod"
+    # view_channel is an alias; discord.py-self reports the canonical flag name.
+    assert payload[0]["allowed"] == ["read_messages"]
+    assert payload[0]["denied"] == ["send_messages"]
+
+
+@pytest.mark.asyncio
+async def test_get_channel_permissions_reports_missing_channel(monkeypatch):
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=None))
+
+    result = await permissions.get_channel_permissions({"channel_id": "500"})
+
+    assert result[0].text == "Channel not found"
+
+
+@pytest.mark.asyncio
+async def test_inspect_effective_permissions_splits_channels(monkeypatch):
+    role = FakeRole()
+    visible = FakeChannel(name="visible", view=True)
+    hidden = FakeChannel(name="hidden", view=False)
+    guild = FakeGuild(roles_list=[role], channels=[visible, hidden])
+    # Take the Role branch so target.permissions is read instead of guild_permissions.
+    monkeypatch.setattr(discord, "Role", FakeRole)
+    monkeypatch.setattr(permissions, "client", FakeClient(guild=guild))
+
+    result = await permissions.inspect_effective_permissions(
+        {"guild_id": "1", "target_id": "10", "target_type": "role"}
+    )
+    payload = json.loads(result[0].text)
+
+    assert payload["accessible_channels"] == ["visible"]
+    assert payload["hidden_channels"] == ["hidden"]
+    assert payload["accessible_channel_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_set_category_permissions_syncs_children(monkeypatch):
+    role = FakeRole()
+    guild = FakeGuild(roles_list=[role])
+    child_a = FakeChannel(name="chat", guild=guild)
+    child_b = FakeChannel(name="voice", guild=guild)
+
+    class FakeCategory(FakeChannel):
+        def __init__(self):
+            super().__init__(name="staff", guild=guild)
+            self.channels = [child_a, child_b]
+
+    category = FakeCategory()
+    monkeypatch.setattr(discord, "CategoryChannel", FakeCategory)
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=category))
+
+    result = await permissions.set_category_permissions(
+        {
+            "category_id": "1",
+            "target_id": "10",
+            "target_type": "role",
+            "deny": ["view_channel"],
+        }
+    )
+
+    assert len(category.calls) == 1
+    assert child_a.calls[0][0] is role
+    assert child_b.calls[0][0] is role
+    assert "synced 2 channel(s): chat, voice" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_set_category_permissions_can_skip_children(monkeypatch):
+    role = FakeRole()
+    guild = FakeGuild(roles_list=[role])
+    child = FakeChannel(name="chat", guild=guild)
+
+    class FakeCategory(FakeChannel):
+        def __init__(self):
+            super().__init__(name="staff", guild=guild)
+            self.channels = [child]
+
+    category = FakeCategory()
+    monkeypatch.setattr(discord, "CategoryChannel", FakeCategory)
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=category))
+
+    result = await permissions.set_category_permissions(
+        {
+            "category_id": "1",
+            "target_id": "10",
+            "target_type": "role",
+            "sync_children": False,
+        }
+    )
+
+    assert child.calls == []
+    assert "synced" not in result[0].text

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -210,6 +210,80 @@ async def test_patch_channel_permissions_requires_changes(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_set_channel_permissions_refuses_to_silently_clear(monkeypatch):
+    role = FakeRole()
+    channel = FakeChannel(guild=FakeGuild(roles_list=[role]))
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.set_channel_permissions(
+        {"channel_id": "500", "target_id": "10", "target_type": "role"}
+    )
+
+    assert "would clear the existing entry" in result[0].text
+    assert channel.calls == []
+
+
+@pytest.mark.asyncio
+async def test_set_channel_permissions_rejects_flag_on_both_sides(monkeypatch):
+    role = FakeRole()
+    channel = FakeChannel(guild=FakeGuild(roles_list=[role]))
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.set_channel_permissions(
+        {
+            "channel_id": "500",
+            "target_id": "10",
+            "target_type": "role",
+            "allow": ["send_messages"],
+            "deny": ["send_messages"],
+        }
+    )
+
+    assert "in both allow and deny: send_messages" in result[0].text
+    assert channel.calls == []
+
+
+@pytest.mark.asyncio
+async def test_set_channel_permissions_accepts_a_member_target(monkeypatch):
+    member = FakeRole(role_id=77, name="someone")
+    guild = FakeGuild(members={77: member})
+    channel = FakeChannel(guild=guild)
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.set_channel_permissions(
+        {
+            "channel_id": "500",
+            "target_id": "77",
+            "target_type": "member",
+            "deny": ["send_messages"],
+        }
+    )
+
+    target, overwrite = channel.calls[0]
+    assert target is member
+    assert overwrite.send_messages is False
+    assert "Set permissions for someone" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_get_channel_permissions_survives_an_uncached_target(monkeypatch):
+    # discord.py substitutes a bare Object when the role or member is not cached.
+    ghost = discord.Object(id=4242)
+    overwrite = discord.PermissionOverwrite()
+    overwrite.send_messages = False
+    channel = FakeChannel(guild=FakeGuild(), overwrites={ghost: overwrite})
+    monkeypatch.setattr(permissions, "client", FakeClient(channel=channel))
+
+    result = await permissions.get_channel_permissions({"channel_id": "500"})
+    payload = json.loads(result[0].text)
+
+    assert payload[0]["target_id"] == "4242"
+    assert payload[0]["target_type"] == "unresolved"
+    assert payload[0]["target_name"] is None
+    assert payload[0]["denied"] == ["send_messages"]
+
+
+@pytest.mark.asyncio
 async def test_remove_channel_permissions_clears_overwrite(monkeypatch):
     role = FakeRole()
     channel = FakeChannel(guild=FakeGuild(roles_list=[role]))
@@ -268,6 +342,29 @@ async def test_inspect_effective_permissions_splits_channels(monkeypatch):
     assert payload["accessible_channels"] == ["visible"]
     assert payload["hidden_channels"] == ["hidden"]
     assert payload["accessible_channel_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_inspect_effective_permissions_accepts_a_member_target(monkeypatch):
+    class FakeMember:
+        id = 77
+        name = "someone"
+        guild_permissions = discord.Permissions(discord.Permissions.all().value)
+
+    member = FakeMember()
+    visible = FakeChannel(name="visible", view=True)
+    guild = FakeGuild(members={77: member}, channels=[visible])
+    monkeypatch.setattr(permissions, "client", FakeClient(guild=guild))
+
+    result = await permissions.inspect_effective_permissions(
+        {"guild_id": "1", "target_id": "77", "target_type": "member"}
+    )
+    payload = json.loads(result[0].text)
+
+    assert payload["target_name"] == "someone"
+    assert payload["target_type"] == "member"
+    assert payload["is_administrator"] is True
+    assert payload["accessible_channels"] == ["visible"]
 
 
 @pytest.mark.asyncio
@@ -388,6 +485,7 @@ async def test_set_category_permissions_can_skip_children(monkeypatch):
             "category_id": "1",
             "target_id": "10",
             "target_type": "role",
+            "deny": ["view_channel"],
             "sync_children": False,
         }
     )

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -64,8 +64,8 @@ class FakeGuild:
 
 
 class FakeChannel:
-    def __init__(self, name="general", guild=None, overwrites=None, view=True):
-        self.id = 500
+    def __init__(self, name="general", guild=None, overwrites=None, view=True, channel_id=500):
+        self.id = channel_id
         self.name = name
         self.guild = guild
         self.overwrites = overwrites or {}
@@ -334,18 +334,21 @@ async def test_set_category_permissions_forwards_reason(monkeypatch):
 async def test_set_category_permissions_reports_partial_progress(monkeypatch):
     role = FakeRole()
     guild = FakeGuild(roles_list=[role])
-    good = FakeChannel(name="chat", guild=guild)
+    # Same name on purpose: Discord allows duplicate channel names, so the
+    # reconciliation list has to be unambiguous.
+    good = FakeChannel(name="chat", guild=guild, channel_id=111)
+    twin = FakeChannel(name="chat", guild=guild, channel_id=222)
 
     class Exploding(FakeChannel):
         async def set_permissions(self, target, overwrite=..., **kwargs):
             raise RuntimeError("500 Internal Server Error")
 
-    bad = Exploding(name="voice", guild=guild)
+    bad = Exploding(name="voice", guild=guild, channel_id=333)
 
     class FakeCategory(FakeChannel):
         def __init__(self):
-            super().__init__(name="staff", guild=guild)
-            self.channels = [good, bad]
+            super().__init__(name="staff", guild=guild, channel_id=999)
+            self.channels = [good, twin, bad]
 
     category = FakeCategory()
     monkeypatch.setattr(discord, "CategoryChannel", FakeCategory)
@@ -358,7 +361,10 @@ async def test_set_category_permissions_reports_partial_progress(monkeypatch):
     text = result[0].text
     assert "500 Internal Server Error" in text
     assert "the category was already updated" in text
-    assert "chat" in text
+    assert "2 channel(s)" in text
+    # Both survivors are named "chat" -- only the ids tell them apart.
+    assert "chat (111)" in text
+    assert "chat (222)" in text
     assert "still have their previous overwrite" in text
 
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -27,6 +27,16 @@ class FakeRole:
         self.edits = []
         self.deleted = False
 
+    # Mirrors discord.Role ordering: equal positions are broken by id, and the
+    # role with the higher id sorts lower.
+    def __lt__(self, other):
+        if self.position == other.position:
+            return self.id > other.id
+        return self.position < other.position
+
+    def __ge__(self, other):
+        return not self < other
+
     async def edit(self, **kwargs):
         self.edits.append(kwargs)
 
@@ -154,6 +164,33 @@ async def test_edit_role_blocks_role_above_own(monkeypatch):
     monkeypatch.setattr(roles, "client", FakeClient(_guild_with(role, my_top_position=20)))
 
     result = await roles.edit_role({"guild_id": "1", "role_id": "10", "name": "nope"})
+
+    assert "at or above your highest role" in result[0].text
+    assert role.edits == []
+
+
+@pytest.mark.asyncio
+async def test_edit_role_allows_tie_broken_below_by_id(monkeypatch):
+    # Same position as our top role, but a higher id, which Discord orders lower.
+    top = FakeRole(role_id=1, name="admin", position=20)
+    role = FakeRole(role_id=99, name="tied-below", position=20)
+    guild = FakeGuild(roles_list=[role, top], me=FakeMe(top))
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    await roles.edit_role({"guild_id": "1", "role_id": "99", "name": "renamed"})
+
+    assert role.edits == [{"name": "renamed"}]
+
+
+@pytest.mark.asyncio
+async def test_edit_role_blocks_tie_broken_above_by_id(monkeypatch):
+    # Same position, lower id, which Discord orders above us.
+    top = FakeRole(role_id=99, name="mine", position=20)
+    role = FakeRole(role_id=1, name="tied-above", position=20)
+    guild = FakeGuild(roles_list=[role, top], me=FakeMe(top))
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    result = await roles.edit_role({"guild_id": "1", "role_id": "1", "name": "nope"})
 
     assert "at or above your highest role" in result[0].text
     assert role.edits == []

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -307,6 +307,63 @@ async def test_reorder_roles_reports_positions_after_sequential_fallback(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_edit_role_blocks_a_destination_above_own_role(monkeypatch):
+    role = FakeRole(role_id=10, name="mod", position=5)
+    guild = _guild_with(role, my_top_position=20)
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    result = await roles.edit_role({"guild_id": "1", "role_id": "10", "position": 25})
+
+    assert "Position 25 is at or above your highest role" in result[0].text
+    assert role.edits == []
+
+
+@pytest.mark.asyncio
+async def test_reorder_roles_blocks_a_destination_above_own_role(monkeypatch):
+    first = FakeRole(role_id=10, name="a", position=1)
+    top = FakeRole(role_id=1, name="admin", position=20)
+    guild = FakeGuild(roles_list=[first, top], me=FakeMe(top))
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    result = await roles.reorder_roles(
+        {"guild_id": "1", "positions": [{"role_id": "10", "position": 30}]}
+    )
+
+    assert "a: Position 30 is at or above your highest role" in result[0].text
+    assert first.edits == []
+
+
+@pytest.mark.asyncio
+async def test_reorder_roles_names_moves_applied_before_a_failure(monkeypatch):
+    class Exploding(FakeRole):
+        async def edit(self, **kwargs):
+            raise RuntimeError("500 Internal Server Error")
+
+    ok_role = FakeRole(role_id=10, name="a", position=1)
+    bad_role = Exploding(role_id=11, name="b", position=2)
+    top = FakeRole(role_id=1, name="admin", position=100)
+    guild = FakeGuild(roles_list=[ok_role, bad_role, top], me=FakeMe(top))
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    result = await roles.reorder_roles(
+        {
+            "guild_id": "1",
+            "positions": [
+                {"role_id": "10", "position": 40},
+                {"role_id": "11", "position": 30},
+            ],
+        }
+    )
+
+    text = result[0].text
+    assert "500 Internal Server Error" in text
+    # Highest destination goes first, so "a" is applied before "b" blows up.
+    assert "1 role(s) were already moved" in text
+    assert "a (10)" in text
+    assert "The rest were not touched" in text
+
+
+@pytest.mark.asyncio
 async def test_reorder_roles_reports_missing_role(monkeypatch):
     top = FakeRole(role_id=1, name="admin", position=100)
     guild = FakeGuild(roles_list=[top], me=FakeMe(top))

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -38,7 +38,13 @@ class FakeRole:
         return not self < other
 
     async def edit(self, **kwargs):
+        # discord.Role.edit returns a new instance and leaves this one untouched.
         self.edits.append(kwargs)
+        return FakeRole(
+            role_id=self.id,
+            name=kwargs.get("name", self.name),
+            position=kwargs.get("position", self.position),
+        )
 
     async def delete(self, **kwargs):
         self.deleted = True
@@ -241,6 +247,63 @@ async def test_reorder_roles_falls_back_to_sequential_edits(monkeypatch):
     assert first.edits == [{"position": 4}]
     assert second.edits == [{"position": 3}]
     assert "Reordered 2 role(s)" in result[0].text
+
+
+class FakeGuildBulk(FakeGuild):
+    """Guild that exposes the bulk endpoint, like discord.py-self 2.0.1."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.bulk_calls = []
+
+    async def edit_role_positions(self, positions, reason=None):
+        self.bulk_calls.append((dict(positions), reason))
+        # Mirrors the library: fresh Role objects, originals left stale.
+        return [
+            FakeRole(role_id=role.id, name=role.name, position=position)
+            for role, position in positions.items()
+        ]
+
+
+@pytest.mark.asyncio
+async def test_reorder_roles_reports_positions_from_the_api_not_stale_cache(monkeypatch):
+    first = FakeRole(role_id=10, name="a", position=1)
+    second = FakeRole(role_id=11, name="b", position=2)
+    top = FakeRole(role_id=1, name="admin", position=100)
+    guild = FakeGuildBulk(roles_list=[first, second, top], me=FakeMe(top))
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    result = await roles.reorder_roles(
+        {
+            "guild_id": "1",
+            "positions": [
+                {"role_id": "10", "position": 40},
+                {"role_id": "11", "position": 30},
+            ],
+        }
+    )
+
+    text = result[0].text
+    assert guild.bulk_calls[0][0] == {first: 40, second: 30}
+    # The originals still say 1 and 2; the report must not.
+    assert (first.position, second.position) == (1, 2)
+    assert "a: asked 40, now 40" in text
+    assert "b: asked 30, now 30" in text
+
+
+@pytest.mark.asyncio
+async def test_reorder_roles_reports_positions_after_sequential_fallback(monkeypatch):
+    first = FakeRole(role_id=10, name="a", position=1)
+    top = FakeRole(role_id=1, name="admin", position=100)
+    guild = FakeGuild(roles_list=[first, top], me=FakeMe(top))
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    result = await roles.reorder_roles(
+        {"guild_id": "1", "positions": [{"role_id": "10", "position": 7}]}
+    )
+
+    assert first.position == 1
+    assert "a: asked 7, now 7" in result[0].text
 
 
 @pytest.mark.asyncio

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,219 @@
+import json
+
+import discord
+import pytest
+
+from discord_py_self_mcp.tools import roles
+
+
+class FakeClient:
+    def __init__(self, guild):
+        self._guild = guild
+
+    def get_guild(self, guild_id):
+        return self._guild
+
+
+class FakeRole:
+    def __init__(self, role_id=10, name="mod", position=5):
+        self.id = role_id
+        self.name = name
+        self.position = position
+        self.color = discord.Color(0x5865F2)
+        self.hoist = False
+        self.mentionable = False
+        self.managed = False
+        self.permissions = discord.Permissions(0)
+        self.edits = []
+        self.deleted = False
+
+    async def edit(self, **kwargs):
+        self.edits.append(kwargs)
+
+    async def delete(self, **kwargs):
+        self.deleted = True
+
+
+class FakeMe:
+    def __init__(self, top_role):
+        self.id = 999
+        self.top_role = top_role
+
+
+class FakeGuild:
+    def __init__(self, roles_list=None, me=None, owner_id=None):
+        self.roles = roles_list or []
+        self.me = me
+        self.owner_id = owner_id
+        self.created = []
+
+    def get_role(self, role_id):
+        for role in self.roles:
+            if role.id == role_id:
+                return role
+        return None
+
+    async def create_role(self, **kwargs):
+        role = FakeRole(role_id=77, name=kwargs.get("name", "new"), position=1)
+        self.created.append(kwargs)
+        return role
+
+
+def _guild_with(role, my_top_position=100):
+    top = FakeRole(role_id=1, name="admin", position=my_top_position)
+    return FakeGuild(roles_list=[role, top], me=FakeMe(top))
+
+
+@pytest.mark.asyncio
+async def test_list_roles_returns_guild_not_found(monkeypatch):
+    monkeypatch.setattr(roles, "client", FakeClient(None))
+
+    result = await roles.list_roles({"guild_id": "1"})
+
+    assert result[0].text == "Guild not found"
+
+
+@pytest.mark.asyncio
+async def test_list_roles_sorts_highest_first(monkeypatch):
+    low = FakeRole(role_id=10, name="member", position=1)
+    high = FakeRole(role_id=11, name="admin", position=9)
+    monkeypatch.setattr(roles, "client", FakeClient(FakeGuild(roles_list=[low, high])))
+
+    result = await roles.list_roles({"guild_id": "1"})
+    payload = json.loads(result[0].text)
+
+    assert [entry["name"] for entry in payload] == ["admin", "member"]
+    assert payload[0]["color"] == "#5865F2"
+
+
+@pytest.mark.asyncio
+async def test_create_role_parses_hex_color(monkeypatch):
+    guild = FakeGuild()
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    result = await roles.create_role(
+        {"guild_id": "1", "name": "staff", "color": "#FF0000", "hoist": True}
+    )
+
+    assert "Created role staff" in result[0].text
+    assert guild.created[0]["color"] == discord.Color(0xFF0000)
+    assert guild.created[0]["hoist"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_role_accepts_permission_names(monkeypatch):
+    guild = FakeGuild()
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    await roles.create_role(
+        {"guild_id": "1", "name": "staff", "permissions": ["kick_members"]}
+    )
+
+    assert guild.created[0]["permissions"].kick_members is True
+    assert guild.created[0]["permissions"].ban_members is False
+
+
+@pytest.mark.asyncio
+async def test_create_role_rejects_unknown_permission_name(monkeypatch):
+    monkeypatch.setattr(roles, "client", FakeClient(FakeGuild()))
+
+    result = await roles.create_role(
+        {"guild_id": "1", "name": "staff", "permissions": ["make_coffee"]}
+    )
+
+    assert "Unknown permission name(s): make_coffee" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_edit_role_without_fields_changes_nothing(monkeypatch):
+    role = FakeRole()
+    monkeypatch.setattr(roles, "client", FakeClient(_guild_with(role)))
+
+    result = await roles.edit_role({"guild_id": "1", "role_id": "10"})
+
+    assert result[0].text == "Nothing to change — pass at least one field"
+    assert role.edits == []
+
+
+@pytest.mark.asyncio
+async def test_edit_role_applies_only_given_fields(monkeypatch):
+    role = FakeRole()
+    monkeypatch.setattr(roles, "client", FakeClient(_guild_with(role)))
+
+    result = await roles.edit_role(
+        {"guild_id": "1", "role_id": "10", "name": "staff", "hoist": True}
+    )
+
+    assert role.edits == [{"name": "staff", "hoist": True}]
+    assert "Edited role mod" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_edit_role_blocks_role_above_own(monkeypatch):
+    role = FakeRole(role_id=10, name="owner-only", position=50)
+    monkeypatch.setattr(roles, "client", FakeClient(_guild_with(role, my_top_position=20)))
+
+    result = await roles.edit_role({"guild_id": "1", "role_id": "10", "name": "nope"})
+
+    assert "at or above your highest role" in result[0].text
+    assert role.edits == []
+
+
+@pytest.mark.asyncio
+async def test_edit_role_allows_guild_owner_above_own_role(monkeypatch):
+    role = FakeRole(role_id=10, name="top", position=50)
+    top = FakeRole(role_id=1, name="mine", position=2)
+    me = FakeMe(top)
+    guild = FakeGuild(roles_list=[role, top], me=me, owner_id=me.id)
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    await roles.edit_role({"guild_id": "1", "role_id": "10", "name": "renamed"})
+
+    assert role.edits == [{"name": "renamed"}]
+
+
+@pytest.mark.asyncio
+async def test_delete_role_reports_name(monkeypatch):
+    role = FakeRole()
+    monkeypatch.setattr(roles, "client", FakeClient(_guild_with(role)))
+
+    result = await roles.delete_role({"guild_id": "1", "role_id": "10"})
+
+    assert result[0].text == "Deleted role mod"
+    assert role.deleted is True
+
+
+@pytest.mark.asyncio
+async def test_reorder_roles_falls_back_to_sequential_edits(monkeypatch):
+    first = FakeRole(role_id=10, name="a", position=1)
+    second = FakeRole(role_id=11, name="b", position=2)
+    top = FakeRole(role_id=1, name="admin", position=100)
+    guild = FakeGuild(roles_list=[first, second, top], me=FakeMe(top))
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    result = await roles.reorder_roles(
+        {
+            "guild_id": "1",
+            "positions": [
+                {"role_id": "10", "position": 4},
+                {"role_id": "11", "position": 3},
+            ],
+        }
+    )
+
+    assert first.edits == [{"position": 4}]
+    assert second.edits == [{"position": 3}]
+    assert "Reordered 2 role(s)" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_reorder_roles_reports_missing_role(monkeypatch):
+    top = FakeRole(role_id=1, name="admin", position=100)
+    guild = FakeGuild(roles_list=[top], me=FakeMe(top))
+    monkeypatch.setattr(roles, "client", FakeClient(guild))
+
+    result = await roles.reorder_roles(
+        {"guild_id": "1", "positions": [{"role_id": "42", "position": 4}]}
+    )
+
+    assert result[0].text == "Role 42 not found"


### PR DESCRIPTION
### Why

`members.py` can assign and unassign roles, but nothing can create, edit, reorder or delete them, and channel permission overwrites are not reachable at all. This adds both, in the existing registry/`TextContent` style.

### Tools

**roles (6)** — `list_roles`, `get_role`, `create_role`, `edit_role`, `delete_role`, `reorder_roles`

**permissions (7)** — `set_role_permissions`, `get_channel_permissions`, `set_channel_permissions`, `patch_channel_permissions`, `remove_channel_permissions`, `set_category_permissions`, `inspect_effective_permissions`

### Design notes

**Hex colours.** `color` takes `#5865F2` as well as an integer, since that is how colours are written everywhere else.

**Permission names.** `permissions` takes a list of flag names (`["manage_roles", "kick_members"]`) as well as a raw bitfield. This matters more than convenience: `Permissions.update()` drops unknown keys silently, so a typo would produce a role quietly missing a permission. Names are validated against `VALID_FLAGS` first and a bad one is reported.

**Hierarchy.** Discord answers "role is not below yours" with a bare 403, which reads like a bug. `edit_role`, `delete_role`, `reorder_roles` and `set_role_permissions` compare positions locally first and name the blocking role. Guild owners are exempt from the check.

**`reorder_roles`.** Moving roles one at a time is the common case for reorganising a server, so this takes a batch. It uses `Guild.edit_role_positions` when present and falls back to sequential `role.edit(position=...)` otherwise.

**`patch_channel_permissions`.** `set_channel_permissions` builds the overwrite with `from_pair`, so it replaces the entry wholesale — changing one flag drops every other flag in that overwrite. The patch variant takes a `flag -> true/false/null` map and leaves the rest alone. `null` clears a flag back to inherit.

**`list_roles`** returns JSON rather than prose, so it can be kept as a snapshot before a reorganisation. Role `position` is guild-wide and moving one role reindexes the others, so having the previous state matters.

### Tests

25 added, in the existing pytest style with monkeypatched module-level `client`. Includes a test that patching one flag preserves the others in the same overwrite, and one that an unknown permission name is rejected rather than silently ignored.

Full suite: **83 passed**.

Note: these were run with `mcp` 1.x installed. On the current unpinned dependency the suite cannot collect at all, for reasons unrelated to this change — see #44.

### Not included

Emoji/icon roles (`icon`, `unicode_emoji`) are not exposed; they need bytes handling and a boost level, and I had no boosted guild to verify against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds MCP tools for managing Discord roles and channel permission overwrites.
- Adds role creation, editing, deletion, listing, permission assignment, and reordering.
- Adds overwrite replacement, patching, removal, category propagation, and effective-permission inspection.
- Registers and documents the new tools and adds focused tests.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the sequential role-reordering fallback can still produce a final ordering different from the requested batch.

The fallback performs independent position edits even though every edit reindexes the roles used by subsequent operations; sorting those edits top-down makes execution deterministic but does not preserve arbitrary batch destinations.

**Files Needing Attention:** discord_py_self_mcp/tools/roles.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| discord_py_self_mcp/tools/roles.py | Implements role management, hierarchy validation, permission parsing, and bulk or sequential role reordering. |
| discord_py_self_mcp/tools/permissions.py | Implements role and channel permission management, category propagation with audit reasons, and identifiable partial-progress reporting. |
| tests/test_roles.py | Covers role parsing, hierarchy behavior, mutation tools, fallback handling, and post-reorder reporting. |
| tests/test_permissions.py | Covers overwrite validation, patch preservation, category synchronization, audit reasons, and partial-progress responses. |
| discord_py_self_mcp/tools/__init__.py | Imports the new modules so their tools are registered. |
| README.md | Documents the new role and permission tools and their replacement-versus-patch semantics. |

<sub>Reviews (7): Last reviewed commit: ["fix: address second review round on over..."](https://github.com/microck/discord.py-self-mcp/commit/ba99c45713b98292a4fe400fa1e30c717c5892f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50060379)</sub>

<!-- /greptile_comment -->